### PR TITLE
Refactor game over handling

### DIFF
--- a/src/tetris/game_state.py
+++ b/src/tetris/game_state.py
@@ -80,3 +80,18 @@ class GameState:
         self.hold_used = False
         self.spawn_tetromino()
 
+    def game_over(self, log_fn=None) -> None:
+        """Log a game-over message and reset the game state.
+
+        ``log_fn`` is an optional callable used for diagnostics.  Any
+        exceptions raised during logging are ignored so that the game loop can
+        continue unhindered.
+        """
+
+        if log_fn is not None:
+            try:
+                log_fn("Game over. Resetting.")
+            except Exception:
+                pass
+        self.reset_game()
+

--- a/src/tetris/run_canvas.py
+++ b/src/tetris/run_canvas.py
@@ -100,16 +100,13 @@ class Runner:
                     # game avoids crashes from attempting to lock out-of-bounds
                     # blocks.
                     if not self.state.active:
-                        self._log("Game over. Resetting.")
-                        self.state.reset_game()
+                        self.state.game_over(self._log)
                     elif not can_move(self.state.board, self.state.active, 0, 0):
-                        self._log("Game over. Resetting.")
-                        self.state.reset_game()
+                        self.state.game_over(self._log)
                     else:
                         self.state.board.lock_piece(self.state.active)
                         if any(self.state.board.grid[0]):
-                            self._log("Game over. Resetting.")
-                            self.state.reset_game()
+                            self.state.game_over(self._log)
                         else:
                             self.state.board.clear_full_rows()
                             self.state.spawn_tetromino()
@@ -134,13 +131,11 @@ class Runner:
             while can_move(self.state.board, self.state.active, 0, 1):
                 self.state.active.move(0, 1)
             if not can_move(self.state.board, self.state.active, 0, 0):
-                self._log("Game over. Resetting.")
-                self.state.reset_game()
+                self.state.game_over(self._log)
             else:
                 self.state.board.lock_piece(self.state.active)
                 if any(self.state.board.grid[0]):
-                    self._log("Game over. Resetting.")
-                    self.state.reset_game()
+                    self.state.game_over(self._log)
                 else:
                     self.state.board.clear_full_rows()
                     self.state.spawn_tetromino()

--- a/src/tetris/run_pygame.py
+++ b/src/tetris/run_pygame.py
@@ -140,21 +140,13 @@ def lock_and_continue(state: GameState) -> None:
     # raise an ``IndexError`` and effectively freeze the game.  Treat such a
     # scenario as a game-over and reset instead of crashing.
     if not can_move(state.board, state.active, 0, 0):
-        try:
-            log("Game over. Resetting.")
-        except Exception:
-            pass
-        state.reset_game()
+        state.game_over(log)
         return
 
     state.board.lock_piece(state.active)
     # If any blocks reach the top row after locking, it's game over.
     if any(cell != 0 for cell in state.board.grid[0]):
-        try:
-            log("Game over. Resetting.")
-        except Exception:
-            pass
-        state.reset_game()
+        state.game_over(log)
         return
 
     cleared = state.board.clear_full_rows()
@@ -177,11 +169,7 @@ def lock_and_continue(state: GameState) -> None:
     state.spawn_tetromino()
     if not can_move(state.board, state.active, 0, 0):
         # Game over -> reset
-        try:
-            log("Game over. Resetting.")
-        except Exception:
-            pass
-        state.reset_game()
+        state.game_over(log)
 
 
 def handle_key(event: pygame.event.Event, state: GameState) -> None:


### PR DESCRIPTION
## Summary
- add `game_over` helper to `GameState` that logs and resets
- use `GameState.game_over` in pygame and canvas runners to remove duplicated code

## Testing
- `python -m pytest`
- `python -m py_compile src/tetris/game_state.py src/tetris/run_canvas.py src/tetris/run_pygame.py`


------
https://chatgpt.com/codex/tasks/task_e_68c480b35d84832288cdc18b0bf4dca8