### PR TITLE
Center layout and refresh lab branding

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -257,37 +257,37 @@
     <div class="aura-shape aura-shape--4"></div>
     <main class="relative z-10 flex flex-col items-center px-6 py-12 md:py-16 gap-12">
       <header class="max-w-3xl text-center">
-        <p class="text-xs uppercase tracking-[0.45em] text-plum/70">Neural Arcade</p>
+        <p class="text-xs uppercase tracking-[0.45em] text-plum/70">AUTO ARCADE</p>
         <h1 class="mt-5 text-4xl md:text-6xl font-display text-citron drop-shadow-[0_18px_40px_rgba(94,74,227,0.35)]">
-          Tetris Intelligence Lab
+          Tetris Reinforcement Learning Lab
         </h1>
-        <p class="mt-4 text-lg md:text-xl text-plum/80">
-          Fine-tune the falling blocks while the AI learns to groove with a synth-inspired palette.
-        </p>
       </header>
       <noscript>
         <div class="glass-panel noscript-alert px-6 py-4 text-base rounded-3xl">
           JavaScript is disabled. Enable it to play.
         </div>
       </noscript>
-      <div
-        class="game relative flex w-full max-w-6xl flex-col items-center gap-10 lg:flex-row lg:items-start lg:justify-center"
-      >
+      <div class="game relative flex w-full max-w-5xl flex-col items-center gap-8">
         <canvas id="canvas" width="300" height="600" tabindex="0" class="shadow-glow"></canvas>
-        <div class="sidebar flex w-full max-w-sm flex-col items-stretch gap-6">
+        <div class="hud grid w-full max-w-4xl grid-cols-1 gap-4 mx-auto sm:grid-cols-3">
           <div class="panel glass-panel px-6 py-6 text-left">
             <span class="panel-title block text-[0.65rem] uppercase tracking-[0.45em] text-plum/80">Next</span>
             <canvas id="preview" width="160" height="160" class="mx-auto mt-4"></canvas>
           </div>
-          <div class="panel glass-panel px-6 py-6 text-left">
+          <div class="panel glass-panel px-6 py-6 text-left sm:col-span-2">
             <span class="panel-title block text-[0.65rem] uppercase tracking-[0.45em] text-plum/80">Training Progress</span>
-            <canvas id="score-plot" width="160" height="120" class="mx-auto mt-4"></canvas>
+            <canvas
+              id="score-plot"
+              width="420"
+              height="220"
+              class="mx-auto mt-4 h-[220px] w-full max-w-[420px]"
+            ></canvas>
           </div>
-          <div class="glass-panel px-6 py-6 text-center">
+          <div class="glass-panel px-6 py-6 text-center sm:col-span-3 flex flex-col items-center gap-3">
             <div id="level" class="text-xs uppercase tracking-[0.45em] text-plum/70">Level: 0</div>
             <div
               id="score"
-              class="mt-3 text-4xl font-display text-citron drop-shadow-[0_14px_35px_rgba(244,247,121,0.35)]"
+              class="text-4xl font-display text-citron drop-shadow-[0_14px_35px_rgba(244,247,121,0.35)]"
             >
               Score: 0
             </div>


### PR DESCRIPTION
## Summary
- center the game area by replacing the sidebar with a centered HUD grid
- enlarge the training progress plot and tighten spacing between the info panels
- update the hero copy to the new AUTO ARCADE / Tetris Reinforcement Learning Lab branding

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c948547f008322bd543e716bf9b07b