### PR TITLE
Refine training HUD layout and chart readability

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -118,12 +118,15 @@
         border: 2px solid rgba(255, 255, 255, 0.18);
         background: #1c1b32;
       }
-      #preview,
+      #preview {
+        display: block;
+      }
       #score-plot {
         display: block;
-        border-radius: 24px;
-        border: 1px solid rgba(255, 255, 255, 0.18);
-        background: rgba(12, 59, 46, 0.08);
+        border-radius: 28px;
+        border: 1px solid rgba(249, 245, 255, 0.16);
+        background: linear-gradient(135deg, rgba(12, 59, 46, 0.18), rgba(22, 22, 41, 0.35));
+        backdrop-filter: blur(6px);
       }
       #network-viz {
         border-radius: 32px;
@@ -267,29 +270,22 @@
           JavaScript is disabled. Enable it to play.
         </div>
       </noscript>
-      <div class="game relative flex w-full max-w-5xl flex-col items-center gap-8">
-        <canvas id="canvas" width="300" height="600" tabindex="0" class="shadow-glow"></canvas>
-        <div class="hud grid w-full max-w-4xl grid-cols-1 gap-4 mx-auto sm:grid-cols-3">
-          <div class="panel glass-panel px-6 py-6 text-left">
-            <span class="panel-title block text-[0.65rem] uppercase tracking-[0.45em] text-plum/80">Next</span>
-            <canvas id="preview" width="160" height="160" class="mx-auto mt-4"></canvas>
-          </div>
-          <div class="panel glass-panel px-6 py-6 text-left sm:col-span-2">
-            <span class="panel-title block text-[0.65rem] uppercase tracking-[0.45em] text-plum/80">Training Progress</span>
-            <canvas
-              id="score-plot"
-              width="420"
-              height="220"
-              class="mx-auto mt-4 h-[220px] w-full max-w-[420px]"
-            ></canvas>
-          </div>
-          <div class="glass-panel px-6 py-6 text-center sm:col-span-3 flex flex-col items-center gap-3">
-            <div id="level" class="text-xs uppercase tracking-[0.45em] text-plum/70">Level: 0</div>
-            <div
-              id="score"
-              class="text-4xl font-display text-citron drop-shadow-[0_14px_35px_rgba(244,247,121,0.35)]"
-            >
-              Score: 0
+      <div class="game relative flex w-full max-w-5xl flex-col items-center gap-10">
+        <div class="flex w-full max-w-5xl flex-col items-center gap-6 md:flex-row md:items-start md:justify-center md:gap-12">
+          <canvas id="canvas" width="300" height="600" tabindex="0" class="shadow-glow"></canvas>
+          <div class="flex w-full max-w-sm flex-col items-center gap-6 md:w-auto md:items-end md:gap-8">
+            <div class="flex flex-col items-center gap-3 md:items-end">
+              <span class="text-sm uppercase tracking-[0.45em] text-plum/80 md:text-right">Next</span>
+              <canvas id="preview" width="160" height="160" class="mt-2 h-[160px] w-[160px]"></canvas>
+            </div>
+            <div class="flex flex-col items-center gap-2 md:items-end md:text-right">
+              <div id="level" class="text-xs uppercase tracking-[0.45em] text-plum/70 md:text-right">Level: 0</div>
+              <div
+                id="score"
+                class="text-4xl font-display text-citron drop-shadow-[0_14px_35px_rgba(244,247,121,0.35)] md:text-right"
+              >
+                Score: 0
+              </div>
             </div>
           </div>
         </div>
@@ -338,6 +334,15 @@
           </label>
           <input id="speed" type="range" min="1" max="50" value="1" class="w-60 md:w-72 accent-citron" />
         </div>
+        <div class="mt-10 flex w-full flex-col items-center gap-4">
+          <span class="text-sm uppercase tracking-[0.45em] text-plum/70 md:text-base">Training Progress</span>
+          <canvas
+            id="score-plot"
+            width="520"
+            height="240"
+            class="h-[240px] w-full max-w-[520px]"
+          ></canvas>
+        </div>
       </section>
       <section class="mt-6 w-full max-w-5xl space-y-6">
         <div id="train-status" class="text-center text-xs uppercase tracking-[0.45em] text-mint/70"></div>
@@ -368,9 +373,7 @@
         const PREV_CELL = 28; // slightly smaller cell for preview
         const BOARD_BG = '#1b1839';
         const GRID_LINE = 'rgba(255, 255, 255, 0.08)';
-        const PREVIEW_BG = '#1f1b3d';
-        const PREVIEW_BORDER = 'rgba(255, 255, 255, 0.18)';
-        const PREVIEW_GRID = 'rgba(255, 255, 255, 0.16)';
+        const PREVIEW_STROKE = 'rgba(249, 245, 255, 0.6)';
         // Performance tuning caps
         const MAX_AI_STEPS_PER_FRAME = 64;
         const speedSlider = document.getElementById('speed');
@@ -574,10 +577,7 @@
             }
           } catch(_) {}
           const W = preview.width, H = preview.height;
-          pctx.fillStyle = PREVIEW_BG;
-          pctx.fillRect(0,0,W,H);
-          pctx.strokeStyle = PREVIEW_BORDER;
-          pctx.strokeRect(0,0,W,H);
+          pctx.clearRect(0, 0, W, H);
           if(!shape) return;
           const state = SHAPES[shape][0];
           let minR=Infinity, minC=Infinity, maxR=-Infinity, maxC=-Infinity;
@@ -588,7 +588,7 @@
             const x = offX + (c-minC)*PREV_CELL;
             const y = offY + (r-minR)*PREV_CELL;
             const color = SHAPE_COLORS[shape] || '#6c7dd9';
-            paintBlock(pctx, color, x, y, PREV_CELL, { shadow: false, stroke: PREVIEW_GRID });
+            paintBlock(pctx, color, x, y, PREV_CELL, { shadow: false, stroke: PREVIEW_STROKE });
           }
         }
 
@@ -1437,36 +1437,150 @@
           function planForCurrentPiece(){ if(!state.active) return null; const w = train.currentWeightsOverride || train.candWeights[train.candIndex] || train.mean; const a=choosePlacement2(w, state.grid, state.active.shape, state.next); if(!a){ return null; } const len=SHAPES[state.active.shape].length; const cur=state.active.rot % len; const needRot=(a.rot - cur + len) % len; return { targetRot:a.rot, targetCol:a.col, rotLeft:needRot, stage:'rotate' }; }
 
           // Scatter plot of raw score per game (all candidates)
-          function updateScorePlot(){
-            const canvas = document.getElementById('score-plot');
-            if(!canvas) return;
-            const ctx = canvas.getContext('2d');
-            const W = canvas.width, H = canvas.height;
-            ctx.clearRect(0,0,W,H);
-            const padL=22, padB=16, padR=6, padT=6;
-            // axes
-            ctx.strokeStyle = '#ccc'; ctx.lineWidth = 1;
-            ctx.beginPath();
-            ctx.moveTo(padL, H-padB); ctx.lineTo(W-padR, H-padB);
-            ctx.moveTo(padL, H-padB); ctx.lineTo(padL, padT);
-            ctx.stroke();
-            const scores = (window.__train && window.__train.gameScores) ? window.__train.gameScores : [];
-            const types  = (window.__train && window.__train.gameModelTypes) ? window.__train.gameModelTypes : [];
-            if(!scores || scores.length===0) return;
-            const maxY = Math.max(1000, Math.max(...scores));
-            const xw = (W - padL - padR), yh = (H - padT - padB);
-            ctx.fillStyle = '#666'; ctx.font = '10px sans-serif';
-            ctx.fillText('0', 4, H-padB+10);
-            ctx.fillText(String(maxY), 2, padT+8);
-            const COLORS = { linear: '#1f77b4', mlp: '#ff7f0e' };
-            for(let i=0;i<scores.length;i++){
-              const x = padL + (scores.length<=1?0:(i/(scores.length-1)))*xw;
-              const y = H - padB - (scores[i]/maxY)*yh;
-              const t = types[i] || 'linear';
-              ctx.fillStyle = COLORS[t] || '#1f77b4';
-              ctx.fillRect(Math.round(x)-1, Math.round(y)-1, 3, 3);
-            }
+        function updateScorePlot(){
+          const canvas = document.getElementById('score-plot');
+          if(!canvas) return;
+          const ctx = canvas.getContext('2d');
+          const W = canvas.width, H = canvas.height;
+          ctx.clearRect(0,0,W,H);
+
+          const padL = 48;
+          const padR = 24;
+          const padT = 26;
+          const padB = 44;
+          const axisColor = 'rgba(249, 245, 255, 0.68)';
+          const gridColor = 'rgba(249, 245, 255, 0.1)';
+
+          const scores = (window.__train && window.__train.gameScores) ? window.__train.gameScores : [];
+          const types  = (window.__train && window.__train.gameModelTypes) ? window.__train.gameModelTypes : [];
+          const xw = Math.max(0, W - padL - padR);
+          const yh = Math.max(0, H - padT - padB);
+
+          const maxScore = scores.length ? Math.max(...scores) : 0;
+          let maxY = Math.ceil(Math.max(10000, maxScore) / 10000) * 10000;
+          if(!Number.isFinite(maxY) || maxY <= 0){
+            maxY = 10000;
           }
+
+          const yTicks = [];
+          for(let tick = 0; tick <= maxY; tick += 10000){
+            yTicks.push(tick);
+          }
+          if(yTicks[yTicks.length - 1] !== maxY){
+            yTicks.push(maxY);
+          }
+
+          ctx.lineWidth = 1;
+          ctx.strokeStyle = gridColor;
+          yTicks.forEach((tick) => {
+            const y = H - padB - (tick / maxY) * yh;
+            ctx.beginPath();
+            ctx.moveTo(padL, y);
+            ctx.lineTo(W - padR, y);
+            ctx.stroke();
+          });
+
+          ctx.strokeStyle = axisColor;
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.moveTo(padL, padT);
+          ctx.lineTo(padL, H - padB);
+          ctx.lineTo(W - padR, H - padB);
+          ctx.stroke();
+
+          ctx.strokeStyle = axisColor;
+          ctx.lineWidth = 1;
+          ctx.fillStyle = axisColor;
+          ctx.font = '11px "Instrument Serif", serif';
+          ctx.textAlign = 'right';
+          ctx.textBaseline = 'middle';
+          yTicks.forEach((tick) => {
+            const y = H - padB - (tick / maxY) * yh;
+            ctx.beginPath();
+            ctx.moveTo(padL - 6, y);
+            ctx.lineTo(padL, y);
+            ctx.stroke();
+            ctx.fillText(tick.toLocaleString(), padL - 10, y);
+          });
+
+          const count = scores.length;
+          if(!count){
+            return;
+          }
+
+          const denom = Math.max(1, count - 1);
+          const desiredTicks = Math.min(8, Math.max(3, Math.round(xw / 70)));
+          let step = 1;
+          if(count > 1){
+            const raw = denom / Math.max(1, desiredTicks - 1);
+            const exponent = Math.floor(Math.log10(raw));
+            const base = Math.pow(10, exponent);
+            const fraction = raw / base;
+            let niceFraction;
+            if(fraction >= 5){
+              niceFraction = 5;
+            } else if(fraction >= 2){
+              niceFraction = 2;
+            } else {
+              niceFraction = 1;
+            }
+            step = Math.max(1, Math.round(niceFraction * base));
+          }
+
+          const tickSet = new Set();
+          for(let tick = 1; tick <= count; tick += step){
+            tickSet.add(Math.min(count, Math.round(tick)));
+          }
+          tickSet.add(count);
+          const xTicks = Array.from(tickSet).sort((a,b) => a - b);
+
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'top';
+          ctx.fillStyle = axisColor;
+          ctx.strokeStyle = axisColor;
+          ctx.lineWidth = 1;
+          xTicks.forEach((tick) => {
+            const ratio = count === 1 ? 1 : (tick - 1) / denom;
+            const x = padL + ratio * xw;
+            ctx.beginPath();
+            ctx.moveTo(x, H - padB);
+            ctx.lineTo(x, H - padB + 6);
+            ctx.stroke();
+            ctx.fillText(String(tick), x, H - padB + 8);
+          });
+
+          const COLORS = { linear: '#76b3ff', mlp: '#ff9a6b' };
+          const safeMaxY = maxY || 1;
+          const points = [];
+          for(let i=0; i<count; i++){
+            const ratio = count === 1 ? 1 : (i / denom);
+            const x = padL + ratio * xw;
+            const y = H - padB - (scores[i] / safeMaxY) * yh;
+            points.push({ x, y, type: types[i] || 'linear' });
+          }
+
+          if(points.length >= 2){
+            ctx.beginPath();
+            ctx.moveTo(points[0].x, points[0].y);
+            for(let i=1; i<points.length; i++){
+              ctx.lineTo(points[i].x, points[i].y);
+            }
+            ctx.strokeStyle = 'rgba(249, 245, 255, 0.25)';
+            ctx.lineWidth = 1.25;
+            ctx.stroke();
+          }
+
+          points.forEach((pt) => {
+            const color = COLORS[pt.type] || COLORS.linear;
+            ctx.beginPath();
+            ctx.arc(pt.x, pt.y, 4, 0, Math.PI * 2);
+            ctx.fillStyle = color;
+            ctx.fill();
+            ctx.lineWidth = 1.2;
+            ctx.strokeStyle = 'rgba(12, 17, 32, 0.85)';
+            ctx.stroke();
+          });
+        }
 
           function runAiMicroStep(){
             if(!state.active){ return false; }


### PR DESCRIPTION
## Summary
- place the next-piece preview beside the playfield and restyle the level/score display to sit directly beneath it without a frame
- relocate the training progress chart below the speed control with an enlarged heading and refreshed styling
- redraw the training progress plot with clearer colors, 10k gridlines, and dynamic x-axis ticks for readability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c94b8d07c88322a520262fb0842665