### PR TITLE
Adjust next block preview alignment

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -273,16 +273,15 @@
       <div class="game relative flex w-full max-w-5xl flex-col items-center gap-10">
         <div class="flex w-full max-w-5xl flex-col items-center gap-6 md:flex-row md:items-start md:justify-center md:gap-12">
           <canvas id="canvas" width="300" height="600" tabindex="0" class="shadow-glow"></canvas>
-          <div class="flex w-full max-w-sm flex-col items-center gap-6 md:w-auto md:items-end md:gap-8">
-            <div class="flex flex-col items-center gap-3 md:items-end">
-              <span class="text-sm uppercase tracking-[0.45em] text-plum/80 md:text-right">Next</span>
-              <canvas id="preview" width="160" height="160" class="mt-2 h-[160px] w-[160px]"></canvas>
+          <div class="flex w-full max-w-sm flex-col items-start gap-6 md:w-auto md:items-start md:gap-8">
+            <div class="flex flex-col items-start gap-3 md:items-start">
+              <canvas id="preview" width="140" height="140" class="h-[140px] w-[140px]"></canvas>
             </div>
-            <div class="flex flex-col items-center gap-2 md:items-end md:text-right">
-              <div id="level" class="text-xs uppercase tracking-[0.45em] text-plum/70 md:text-right">Level: 0</div>
+            <div class="flex flex-col items-start gap-2 md:items-start md:text-left">
+              <div id="level" class="text-xs uppercase tracking-[0.45em] text-plum/70">Level: 0</div>
               <div
                 id="score"
-                class="text-4xl font-display text-citron drop-shadow-[0_14px_35px_rgba(244,247,121,0.35)] md:text-right"
+                class="text-4xl font-display text-citron drop-shadow-[0_14px_35px_rgba(244,247,121,0.35)]"
               >
                 Score: 0
               </div>


### PR DESCRIPTION
## Summary
- remove the "Next" label and tighten the next-block preview next to the board
- left-align the level and score text with the preview window

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c94f8d93748322841606d199db7f21