### PR TITLE
Make all buttons green

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -47,6 +47,8 @@
     <style>
       :root {
         color-scheme: dark;
+        --button-gradient: linear-gradient(135deg, #1f6f4d, #4fb272);
+        --button-text-color: #f4fff6;
       }
       body {
         position: relative;
@@ -172,8 +174,8 @@
         height: 62px;
         border-radius: 22px;
         border: none;
-        background: linear-gradient(135deg, #f4f779, #8de1ad);
-        color: #1b1839;
+        background: var(--button-gradient);
+        color: var(--button-text-color);
         font-size: 26px;
         font-weight: 600;
         letter-spacing: 0.04em;
@@ -198,13 +200,10 @@
         transform: translateY(1px) scale(0.97);
         box-shadow: 0 8px 18px rgba(17, 17, 31, 0.4) inset;
       }
-      .icon-btn--violet {
-        background: linear-gradient(135deg, #5e4ae3, #c09fe4);
-        color: #f9f5ff;
-      }
+      .icon-btn--violet,
       .icon-btn--emerald {
-        background: linear-gradient(135deg, #8de1ad, #2f6b49);
-        color: #0f3b2e;
+        background: var(--button-gradient);
+        color: var(--button-text-color);
       }
       .icon-btn--wide {
         width: auto;


### PR DESCRIPTION
## Summary
- use CSS custom properties to define a shared green gradient and text color for control buttons
- apply the unified styling to all button variants so every button appears green

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c966527fac8322a8f52c589290fd62