### PR TITLE
Reduce max level to 10 for faster speedup

### DIFF
--- a/src/tetris/utils.py
+++ b/src/tetris/utils.py
@@ -15,11 +15,11 @@ def gravity_interval_ms(level: int) -> float:
     """Return the fall interval in milliseconds for ``level``.
 
     The interval decreases as the level rises, speeding up the falling
-    pieces.  For level ``29`` and above the function returns ``0`` to
+    pieces.  For level ``10`` and above the function returns ``0`` to
     indicate that the active piece should drop to the bottom immediately.
     """
 
-    if level >= 29:
+    if level >= 10:
         return 0.0
     # Exponentially decrease the delay but keep a practical lower bound
     return max(20.0, BASE_GRAVITY_MS * (0.85 ** level))

--- a/tests/test_gravity.py
+++ b/tests/test_gravity.py
@@ -6,10 +6,10 @@ from tetris.utils import gravity_interval_ms
 
 def test_gravity_speed_increases_with_level():
     assert gravity_interval_ms(1) < gravity_interval_ms(0)
-    assert gravity_interval_ms(29) == 0
+    assert gravity_interval_ms(10) == 0
 
 
-def test_level_29_drops_piece_immediately(monkeypatch):
+def test_level_10_drops_piece_immediately(monkeypatch):
     class DummyWindow:
         def requestAnimationFrame(self, _):
             return 0
@@ -36,7 +36,7 @@ def test_level_29_drops_piece_immediately(monkeypatch):
     runner.state = GameState()
     runner.state.reset_game()
     runner.running = True
-    runner.state.level = 29
+    runner.state.level = 10
     active_before = runner.state.active
     pieces_before = runner.state.pieces
     runner._tick(500)

--- a/tests/test_path_feasibility.py
+++ b/tests/test_path_feasibility.py
@@ -20,14 +20,14 @@ def test_deep_obstacle_blocks_path():
     # obstacle a few rows below the spawn to ensure the path check accounts for
     # bricks already on the board.
     board.grid[2][2] = 1
-    actions = _enumerate_placements(board, TetrominoType.I, level=20)
+    actions = _enumerate_placements(board, TetrominoType.I, level=9)
     cols = [a.column for a in actions]
     assert all(c >= 2 for c in cols), cols
 
 
-def test_level_29_no_horizontal_movement():
+def test_level_10_no_horizontal_movement():
     board = Board()
-    actions = _enumerate_placements(board, TetrominoType.I, level=29)
+    actions = _enumerate_placements(board, TetrominoType.I, level=10)
     cols = {a.column for a in actions}
     assert cols == {board.width // 2 - 2}
 

--- a/web/index.html
+++ b/web/index.html
@@ -504,14 +504,13 @@
 
         const emptyGrid = () => Array.from({length: HEIGHT}, () => Array(WIDTH).fill(0));
 
-        // Level speed table roughly matching classic NES Tetris
+        // Level speed table roughly matching classic NES Tetris up to level 9
         const LEVEL_FRAMES = {
-          0:48,1:43,2:38,3:33,4:28,5:23,6:18,7:13,8:8,9:6,
-          10:5,11:5,12:5,13:4,14:4,15:4,16:3,17:3,18:3,19:2,
-          20:2,21:2,22:2,23:2,24:2,25:2,26:2,27:2,28:2,29:1
+          0:48,1:43,2:38,3:33,4:28,5:23,6:18,7:13,8:8,9:6
         };
         const gravityForLevel = (lvl) => {
-          const frames = LEVEL_FRAMES[Math.min(lvl,29)];
+          if (lvl >= 10) return 0;
+          const frames = LEVEL_FRAMES[lvl] ?? LEVEL_FRAMES[9];
           return (frames/60)*1000; // convert frames to ms
         };
 
@@ -1452,8 +1451,8 @@
               return true;
             }
 
-            // Level 29: treat as instant drop (no horizontal movement)
-            if(level >= 29) return false;
+            // Level 10: treat as instant drop (no horizontal movement)
+            if(level >= 10) return false;
 
             // Estimate how many horizontal moves fit per gravity tick
             const gravity = gravityForLevel(level);


### PR DESCRIPTION
## Summary
- end gravity-based movement at level 10 so pieces drop instantly once the faster cap is reached
- adjust placement feasibility logic and regression tests to reflect the new level cutoff
- update the web UI gravity table and comments to stay consistent with the Python engine

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c966ecd9288322b7cec758c555abf8