### PR TITLE
Reduce spacing between board and preview

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -270,7 +270,7 @@
         </div>
       </noscript>
       <div class="game relative flex w-full max-w-5xl flex-col items-center gap-10">
-        <div class="flex w-full max-w-5xl flex-col items-center gap-6 md:flex-row md:items-start md:justify-center md:gap-12">
+        <div class="flex w-full max-w-5xl flex-col items-center gap-4 md:flex-row md:items-start md:justify-center md:gap-6">
           <canvas id="canvas" width="300" height="600" tabindex="0" class="shadow-glow"></canvas>
           <div class="flex w-full max-w-sm flex-col items-start gap-6 md:w-auto md:items-start md:gap-8">
             <div class="flex flex-col items-start gap-3 md:items-start">


### PR DESCRIPTION
## Summary
- reduce the horizontal gap between the playfield and the next piece preview by tightening the flex layout spacing

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c972141c608322a73269141c0bcd6a