### PR TITLE
Add Tetris well feature to feature pipelines

### DIFF
--- a/src/tetris/features.py
+++ b/src/tetris/features.py
@@ -1,0 +1,216 @@
+"""Feature extraction helpers mirroring the web client implementation.
+
+The functions in this module compute the same normalized feature vector used by
+``web/index.html`` so that Python-side experiments and unit tests can reason
+about the identical inputs as the browser trainer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from .board import Board
+
+WIDTH = Board.width
+HEIGHT = Board.height
+
+GridLike = Sequence[Sequence[int]]
+
+
+@dataclass(frozen=True)
+class WellMetrics:
+    """Summary statistics describing wells on the board."""
+
+    well_sum: int
+    edge_well: int
+    max_well_depth: int
+    well_count: int
+    tetris_well: int
+
+
+FEATURE_NAMES = [
+    "Lines",
+    "Lines²",
+    "Single Clear",
+    "Double Clear",
+    "Triple Clear",
+    "Tetris",
+    "Holes",
+    "Bumpiness",
+    "Max Height",
+    "Well Sum",
+    "Edge Wells",
+    "Tetris Well",
+    "Contact",
+    "Row Transitions",
+    "Col Transitions",
+    "Aggregate Height",
+]
+FEAT_DIM = len(FEATURE_NAMES)
+
+
+def _cell_filled(grid: GridLike, row: int, col: int) -> bool:
+    return bool(grid[row][col])
+
+
+def column_heights(grid: GridLike) -> list[int]:
+    heights = [0] * WIDTH
+    for col in range(WIDTH):
+        row = 0
+        while row < HEIGHT and not _cell_filled(grid, row, col):
+            row += 1
+        heights[col] = HEIGHT - row
+    return heights
+
+
+def count_holes(grid: GridLike) -> int:
+    holes = 0
+    for col in range(WIDTH):
+        seen_block = False
+        for row in range(HEIGHT):
+            if _cell_filled(grid, row, col):
+                seen_block = True
+            elif seen_block:
+                holes += 1
+    return holes
+
+
+def bumpiness(heights: Sequence[int]) -> int:
+    total = 0
+    for col in range(WIDTH - 1):
+        total += abs(heights[col] - heights[col + 1])
+    return total
+
+
+def well_metrics(heights: Sequence[int]) -> WellMetrics:
+    well_sum = 0
+    edge_well = 0
+    max_depth = 0
+    well_count = 0
+    for col in range(WIDTH):
+        left = heights[col - 1] if col > 0 else float("inf")
+        right = heights[col + 1] if col < WIDTH - 1 else float("inf")
+        min_neighbour = left if left < right else right
+        depth = min_neighbour - heights[col]
+        if depth > 0:
+            well_sum += depth
+            well_count += 1
+            if depth > max_depth:
+                max_depth = depth
+        if col == 0:
+            edge_well = max(edge_well, right - heights[0])
+        if col == WIDTH - 1:
+            edge_well = max(edge_well, left - heights[WIDTH - 1])
+    tetris_well = max_depth if well_count == 1 else 0
+    return WellMetrics(
+        well_sum=well_sum,
+        edge_well=max(0, edge_well),
+        max_well_depth=max_depth,
+        well_count=well_count,
+        tetris_well=tetris_well,
+    )
+
+
+def contact_area(grid: GridLike) -> int:
+    contact = 0
+    for row in range(HEIGHT):
+        for col in range(WIDTH):
+            if not _cell_filled(grid, row, col):
+                continue
+            if row == HEIGHT - 1 or _cell_filled(grid, row + 1, col):
+                contact += 1
+            if col > 0 and _cell_filled(grid, row, col - 1):
+                contact += 1
+            if col < WIDTH - 1 and _cell_filled(grid, row, col + 1):
+                contact += 1
+    return contact
+
+
+def row_transitions(grid: GridLike) -> int:
+    transitions = 0
+    for row in range(HEIGHT):
+        prev = 0
+        for col in range(WIDTH):
+            cur = 1 if _cell_filled(grid, row, col) else 0
+            if cur != prev:
+                transitions += 1
+                prev = cur
+        if prev != 0:
+            transitions += 1
+    return transitions
+
+
+def col_transitions(grid: GridLike) -> int:
+    transitions = 0
+    for col in range(WIDTH):
+        prev = 0
+        for row in range(HEIGHT):
+            cur = 1 if _cell_filled(grid, row, col) else 0
+            if cur != prev:
+                transitions += 1
+                prev = cur
+        if prev != 0:
+            transitions += 1
+    return transitions
+
+
+def features_from_grid(grid: GridLike, lines: int) -> list[float]:
+    heights = column_heights(grid)
+    holes = count_holes(grid)
+    bump = bumpiness(heights)
+    max_height = max(heights) if heights else 0
+    wells = well_metrics(heights)
+    contact = contact_area(grid)
+    row_trans = row_transitions(grid)
+    col_trans = col_transitions(grid)
+    aggregate_height = sum(heights)
+
+    cleared = int(lines)
+    s_lines = cleared / 4.0
+    s_lines_sq = (cleared * cleared) / 16.0
+    denom_area = WIDTH * HEIGHT if WIDTH * HEIGHT else 1
+    s_holes = holes / denom_area
+    s_bump = bump / (((WIDTH - 1) * HEIGHT) if WIDTH > 1 else 1)
+    s_max_h = max_height / HEIGHT if HEIGHT else 0.0
+    s_well = wells.well_sum / denom_area
+    s_edge = wells.edge_well / HEIGHT if HEIGHT else 0.0
+    s_tetris = wells.tetris_well / HEIGHT if HEIGHT else 0.0
+    s_contact = contact / (WIDTH * HEIGHT * 2) if WIDTH and HEIGHT else 0.0
+    s_row = row_trans / denom_area
+    s_col = col_trans / denom_area
+    s_agg = aggregate_height / denom_area
+
+    return [
+        s_lines,
+        s_lines_sq,
+        1.0 if cleared == 1 else 0.0,
+        1.0 if cleared == 2 else 0.0,
+        1.0 if cleared == 3 else 0.0,
+        1.0 if cleared == 4 else 0.0,
+        s_holes,
+        s_bump,
+        s_max_h,
+        s_well,
+        s_edge,
+        s_tetris,
+        s_contact,
+        s_row,
+        s_col,
+        s_agg,
+    ]
+
+
+__all__ = [
+    "FEATURE_NAMES",
+    "FEAT_DIM",
+    "WellMetrics",
+    "column_heights",
+    "count_holes",
+    "bumpiness",
+    "well_metrics",
+    "contact_area",
+    "row_transitions",
+    "col_transitions",
+    "features_from_grid",
+]

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from tetris.board import Board
+from tetris.features import FEATURE_NAMES, FEAT_DIM, features_from_grid
+
+
+def test_tetris_well_positive_for_single_deep_well() -> None:
+    board = Board()
+    well_col = 4
+    depth = 6
+    for row in range(Board.height - depth, Board.height):
+        for col in range(Board.width):
+            if col == well_col:
+                continue
+            board.set_cell(row, col, 1)
+
+    features = features_from_grid(board.grid, lines=0)
+    assert len(features) == FEAT_DIM
+    idx = FEATURE_NAMES.index("Tetris Well")
+    expected = depth / Board.height
+    assert features[idx] == pytest.approx(expected)
+    assert features[idx] > 0

--- a/web/index.html
+++ b/web/index.html
@@ -422,6 +422,10 @@
               <dd class="text-sm text-plum/80">Deepest left or right edge indentation relative to its lone neighbor.</dd>
             </div>
             <div>
+              <dt class="font-semibold text-shell">Tetris Well</dt>
+              <dd class="text-sm text-plum/80">Depth of the single deepest well when it is unique, scaled by board height.</dd>
+            </div>
+            <div>
               <dt class="font-semibold text-shell">Contact</dt>
               <dd class="text-sm text-plum/80">Normalized surface area where blocks touch neighbors or the floor.</dd>
             </div>
@@ -898,6 +902,7 @@
             'Max Height',
             'Well Sum',
             'Edge Wells',
+            'Tetris Well',
             'Contact',
             'Row Transitions',
             'Col Transitions',
@@ -960,8 +965,8 @@
           let newWeightArray = (n) => allocWeights(n, DEFAULT_DTYPE);
 
           // Initial weights for Linear model (intentionally poor to make the very first attempt worse)
-          // Order: [lines, lines2, is1, is2, is3, is4, holes, bumpiness, maxH, wellSum, edgeWell, contact, rowTrans, colTrans, aggH]
-          const INITIAL_MEAN_LINEAR_BASE = [0.0, 0.0, 0.6, 0.0, 0.0, 0.0, 0.4, 0.2, 0.1, 0.1, 0.0, 0.0, 0.1, 0.1, 0.2];
+          // Order: [lines, lines2, is1, is2, is3, is4, holes, bumpiness, maxH, wellSum, edgeWell, tetrisWell, contact, rowTrans, colTrans, aggH]
+          const INITIAL_MEAN_LINEAR_BASE = [0.0, 0.0, 0.6, 0.0, 0.0, 0.0, 0.4, 0.2, 0.1, 0.1, 0.0, 0.0, 0.0, 0.1, 0.1, 0.2];
           const INITIAL_STD_LINEAR_BASE  = new Array(FEAT_DIM).fill(0.4);
 
           function paramDim(){ return currentModelType === 'mlp' ? mlpParamDim() : FEAT_DIM; }
@@ -1712,7 +1717,34 @@
           function columnHeights(grid){ const h=Array(WIDTH).fill(0); for(let c=0;c<WIDTH;c++){ let r=0; while(r<HEIGHT && grid[r][c]===0) r++; h[c]=HEIGHT-r; } return h; }
           function countHoles(grid){ let holes=0; for(let c=0;c<WIDTH;c++){ let seen=false; for(let r=0;r<HEIGHT;r++){ const v=grid[r][c]; if(v){ seen=true; } else if(seen){ holes++; } } } return holes; }
           function bumpiness(heights){ let b=0; for(let c=0;c<WIDTH-1;c++) b+=Math.abs(heights[c]-heights[c+1]); return b; }
-          function wellMetrics(heights){ let wellSum=0; let edgeWell=0; for(let c=0;c<WIDTH;c++){ let left = (c>0)?heights[c-1]:Infinity; let right = (c<WIDTH-1)?heights[c+1]:Infinity; let minNbr = Math.min(left,right); let depth = minNbr - heights[c]; if(depth>0) wellSum += depth; if(c===0) edgeWell = Math.max(edgeWell, right - heights[0]); if(c===WIDTH-1) edgeWell = Math.max(edgeWell, left - heights[WIDTH-1]); } return {wellSum, edgeWell: Math.max(0, edgeWell)}; }
+          function wellMetrics(heights){
+            let wellSum=0;
+            let edgeWell=0;
+            let maxWellDepth=0;
+            let wellCount=0;
+            for(let c=0;c<WIDTH;c++){
+              const left = (c>0)?heights[c-1]:Infinity;
+              const right = (c<WIDTH-1)?heights[c+1]:Infinity;
+              const minNbr = Math.min(left,right);
+              const depth = minNbr - heights[c];
+              if(depth>0){
+                wellSum += depth;
+                wellCount++;
+                if(depth>maxWellDepth){
+                  maxWellDepth = depth;
+                }
+              }
+              if(c===0){
+                edgeWell = Math.max(edgeWell, right - heights[0]);
+              }
+              if(c===WIDTH-1){
+                edgeWell = Math.max(edgeWell, left - heights[WIDTH-1]);
+              }
+            }
+            const safeEdge = Math.max(0, edgeWell);
+            const tetrisWell = (wellCount === 1) ? maxWellDepth : 0;
+            return {wellSum, edgeWell: safeEdge, maxWellDepth, wellCount, tetrisWell};
+          }
           function contactArea(g){ let contact=0; for(let r=0;r<HEIGHT;r++){ for(let c=0;c<WIDTH;c++){ if(!g[r][c]) continue; // bottom
                 if(r===HEIGHT-1 || g[r+1][c]) contact++; // left
                 if(c>0 && g[r][c-1]) contact++; // right
@@ -1720,11 +1752,11 @@
           function rowTransitions(g){ let t=0; for(let r=0;r<HEIGHT;r++){ let prev=0; for(let c=0;c<WIDTH;c++){ const cur = g[r][c]?1:0; if(cur!==prev) t++; prev=cur; } if(prev!==0) t++; } return t; }
           function colTransitions(g){ let t=0; for(let c=0;c<WIDTH;c++){ let prev=0; for(let r=0;r<HEIGHT;r++){ const cur = g[r][c]?1:0; if(cur!==prev) t++; prev=cur; } if(prev!==0) t++; } return t; }
           function simulateAfterPlacement(grid, shape, rot, col){ const g=copyGrid(grid); const p=new Piece(shape); p.rot=rot; p.row=0; p.col=col; const fr=dropRowSim(g,p); if(fr===null) return null; p.row=fr; lockSim(g,p); const lines=clearRowsSim(g); return {grid:g, lines}; }
-          function featuresFromGrid(g, lines){ const h=columnHeights(g); const Holes=countHoles(g); const Bump=bumpiness(h); const maxH=Math.max(...h); const {wellSum, edgeWell}=wellMetrics(h); const Contact=contactArea(g); const rT=rowTransitions(g); const cT=colTransitions(g); const aggH=h.reduce((a,b)=>a+b,0);
+          function featuresFromGrid(g, lines){ const h=columnHeights(g); const Holes=countHoles(g); const Bump=bumpiness(h); const maxH=Math.max(...h); const {wellSum, edgeWell, tetrisWell}=wellMetrics(h); const Contact=contactArea(g); const rT=rowTransitions(g); const cT=colTransitions(g); const aggH=h.reduce((a,b)=>a+b,0);
             // Scaling
-            const sLines = lines/4; const sLines2=(lines*lines)/16; const sHoles=Holes/(WIDTH*HEIGHT); const sBump=Bump/((WIDTH-1)*HEIGHT); const sMaxH=maxH/HEIGHT; const sWell=wellSum/(WIDTH*HEIGHT); const sEdge=edgeWell/HEIGHT; const sContact=Contact/(WIDTH*HEIGHT*2); const sRT=rT/(WIDTH*HEIGHT); const sCT=cT/(WIDTH*HEIGHT); const sAgg=aggH/(WIDTH*HEIGHT);
+            const sLines = lines/4; const sLines2=(lines*lines)/16; const sHoles=Holes/(WIDTH*HEIGHT); const sBump=Bump/((WIDTH-1)*HEIGHT); const sMaxH=maxH/HEIGHT; const sWell=wellSum/(WIDTH*HEIGHT); const sEdge=edgeWell/HEIGHT; const sTetris=tetrisWell/HEIGHT; const sContact=Contact/(WIDTH*HEIGHT*2); const sRT=rT/(WIDTH*HEIGHT); const sCT=cT/(WIDTH*HEIGHT); const sAgg=aggH/(WIDTH*HEIGHT);
             const is1=lines===1?1:0, is2=lines===2?1:0, is3=lines===3?1:0, is4=lines===4?1:0;
-            return [sLines, sLines2, is1, is2, is3, is4, sHoles, sBump, sMaxH, sWell, sEdge, sContact, sRT, sCT, sAgg]; }
+            return [sLines, sLines2, is1, is2, is3, is4, sHoles, sBump, sMaxH, sWell, sEdge, sTetris, sContact, sRT, sCT, sAgg]; }
           function featuresForPlacement(grid, shape, rot, col){ const sim=simulateAfterPlacement(grid, shape, rot, col); if(!sim) return null; const feats = featuresFromGrid(sim.grid, sim.lines); return { feats, lines: sim.lines, grid: sim.grid } }
           function dot(weights, feats){ let s=0; for(let d=0; d<FEAT_DIM; d++) s+=weights[d]*feats[d]; return s; }
           function scorePlacement(weights, grid, shape, act){ const ff=featuresForPlacement(grid, shape, act.rot, act.col); if(!ff) return -Infinity; return dot(weights, ff.feats); }


### PR DESCRIPTION
## Summary
- extend the browser trainer to track well counts, deepest wells, and expose a new "Tetris Well" feature
- mirror the feature computation in Python, keeping the feature list and normalization in sync with the web client
- add a unit test that confirms a board with a single deep well produces a positive Tetris Well value

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c97a532ec88322811e09f378e402b1