### PR TITLE
Limit logged performance summary rows

### DIFF
--- a/examples/profile_placements.py
+++ b/examples/profile_placements.py
@@ -70,9 +70,11 @@ def print_summary(tracker: PerformanceTracker, limit: int = 10) -> None:
 
 def log_summary(tracker: PerformanceTracker, *, limit: int, index: int) -> list[dict[str, float | int]]:
     summary = tracker.summary(sort_by="total")
-    message = _format_summary(summary, limit=limit)
+    limit = max(0, limit)
+    limited_summary = summary[:limit] if limit else []
+    message = _format_summary(limited_summary, limit=limit)
     LOGGER.info("Simulation %d performance: %s", index, message)
-    return summary
+    return limited_summary
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_profile_logging.py
+++ b/tests/test_profile_logging.py
@@ -1,0 +1,39 @@
+import logging
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from examples.profile_placements import log_summary
+from tetris.perf import PerformanceTracker
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.current = 0.0
+
+    def advance(self, delta: float) -> None:
+        self.current += delta
+
+    def __call__(self) -> float:
+        return self.current
+
+
+def test_log_summary_limits_rows_and_output(caplog):
+    clock = FakeClock()
+    tracker = PerformanceTracker(clock=clock)
+    with tracker.section("slow"):
+        clock.advance(0.5)
+    with tracker.section("fast"):
+        clock.advance(0.1)
+
+    with caplog.at_level(logging.INFO, logger="examples.profile_placements"):
+        summary = log_summary(tracker, limit=1, index=7)
+
+    assert len(summary) == 1
+    assert summary[0]["name"] == "slow"
+    message = "".join(caplog.messages)
+    assert "slow" in message
+    assert "fast" not in message


### PR DESCRIPTION
## Summary
- ensure the performance profiling log helper returns only the requested number of rows and logs the same limited view
- add a regression test that captures the logging output to verify only the requested section is reported

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c98167cd0c8322bb3a26832021edf8