### PR TITLE
Log warning when headless model falls back

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2475,6 +2475,11 @@
             if(train.enabled && train.useSimplifiedModel){
               const headlessPlan = planForCurrentPieceHeadless(w);
               if(headlessPlan) return headlessPlan;
+              const warnMsg = '⚠️ Headless model unavailable; falling back to full board evaluation.';
+              log(warnMsg);
+              if(typeof console !== 'undefined' && typeof console.warn === 'function'){
+                console.warn(warnMsg);
+              }
             }
             const a = choosePlacement2(w, state.grid, state.active.shape, state.next);
             if(!a){ return null; }


### PR DESCRIPTION
## Summary
- add a diagnostics entry when the headless planner cannot produce a move and the trainer falls back to the full board search
- mirror the warning in the browser console via console.warn to highlight the degraded mode

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca30f34144832298f2a8dc80508678