### PR TITLE
Add historical model slider and snapshot storage

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -200,6 +200,62 @@
         transform: translateY(1px) scale(0.97);
         box-shadow: 0 8px 18px rgba(17, 17, 31, 0.4) inset;
       }
+      #model-history-slider {
+        width: 100%;
+        height: 6px;
+        margin-top: 4px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, rgba(94, 74, 227, 0.35), rgba(141, 225, 173, 0.55));
+        box-shadow: inset 0 1px 0 rgba(249, 245, 255, 0.25);
+        outline: none;
+        cursor: pointer;
+        -webkit-appearance: none;
+        appearance: none;
+        transition: box-shadow 0.2s ease, opacity 0.2s ease;
+      }
+      #model-history-slider:focus-visible {
+        box-shadow: 0 0 0 3px rgba(94, 74, 227, 0.35);
+      }
+      #model-history-slider:disabled {
+        cursor: not-allowed;
+        opacity: 0.35;
+      }
+      #model-history-slider::-webkit-slider-runnable-track {
+        height: 6px;
+        border-radius: 999px;
+        background: transparent;
+      }
+      #model-history-slider::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        border: 2px solid rgba(94, 74, 227, 0.75);
+        background: #f9f5ff;
+        box-shadow: 0 4px 12px rgba(15, 15, 36, 0.35);
+        transition: transform 0.2s ease;
+      }
+      #model-history-slider::-webkit-slider-thumb:hover {
+        transform: scale(1.06);
+      }
+      #model-history-slider::-moz-range-track {
+        height: 6px;
+        border-radius: 999px;
+        background: transparent;
+      }
+      #model-history-slider::-moz-range-thumb {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        border: 2px solid rgba(94, 74, 227, 0.75);
+        background: #f9f5ff;
+        box-shadow: 0 4px 12px rgba(15, 15, 36, 0.35);
+        transition: transform 0.2s ease;
+      }
+      #model-history-slider::-moz-range-thumb:hover {
+        transform: scale(1.06);
+      }
       .icon-btn--violet,
       .icon-btn--emerald {
         background: var(--button-gradient);
@@ -464,6 +520,26 @@
           aria-live="polite"
         ></div>
         <div id="network-viz" aria-label="Network weight visualization" class="glass-panel mx-auto h-[260px] w-full overflow-hidden p-6"></div>
+        <div class="mx-auto mt-4 w-full max-w-5xl space-y-2">
+          <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-plum/70">
+            <span>Model history</span>
+            <span id="model-history-label" class="text-mint/80" aria-live="polite">Live (current training)</span>
+          </div>
+          <input
+            id="model-history-slider"
+            type="range"
+            min="0"
+            max="0"
+            value="0"
+            step="1"
+            class="w-full"
+            aria-label="Scrub through saved best models by generation"
+            disabled
+          />
+          <div id="model-history-meta" class="text-xs text-plum/70">
+            Best-of-generation snapshots will appear as training progresses.
+          </div>
+        </div>
         <div
           id="diagnostics"
           aria-live="polite"
@@ -560,6 +636,9 @@
         const trainStatus = document.getElementById('train-status');
         const architectureEl = document.getElementById('model-architecture');
         const networkVizEl = document.getElementById('network-viz');
+        const historySlider = document.getElementById('model-history-slider');
+        const historyLabel = document.getElementById('model-history-label');
+        const historyMeta = document.getElementById('model-history-meta');
         const mlpConfigEl = document.getElementById('mlp-config');
         const mlpHiddenCountSel = document.getElementById('mlp-hidden-count');
         const mlpLayerControlsEl = document.getElementById('mlp-layer-controls');
@@ -1351,6 +1430,16 @@
 
           function paramDim(){ return currentModelType === 'mlp' ? mlpParamDim() : FEAT_DIM; }
           function makeTyped(vals){ const arr = newWeightArray(vals.length); for(let i=0;i<vals.length;i++) arr[i]=vals[i]; return arr; }
+          function cloneWeightsArray(source){
+            if(!source || !source.length){
+              return new Float64Array(0);
+            }
+            const copy = new Float64Array(source.length);
+            for(let i = 0; i < source.length; i++){
+              copy[i] = source[i];
+            }
+            return copy;
+          }
           function initialMean(model, layers = mlpHiddenLayers){
             if(model === 'mlp'){
               const dim = mlpParamDim(layers);
@@ -1380,6 +1469,120 @@
               return `Architecture: ${parts.join(' → ')}`;
             }
             return `Linear policy with ${FEAT_DIM} inputs`;
+          }
+
+          function describeSnapshotArchitecture(entry){
+            if(!entry){
+              return describeModelArchitecture();
+            }
+            const genLabel = Number.isFinite(entry.gen) ? `Gen ${entry.gen}` : 'Saved model';
+            const layerSizes = Array.isArray(entry.layerSizes) ? entry.layerSizes : null;
+            if(entry.modelType === 'mlp' && layerSizes && layerSizes.length >= 2){
+              const parts = layerSizes.map((size, idx) => {
+                if(idx === 0) return `${size} in`;
+                if(idx === layerSizes.length - 1) return `${size} out`;
+                return `${size}`;
+              });
+              return `${genLabel} — ${parts.join(' → ')}`;
+            }
+            if(entry.modelType === 'linear'){
+              const inputCount = layerSizes && layerSizes.length ? layerSizes[0] : FEAT_DIM;
+              return `${genLabel} — Linear policy with ${inputCount} inputs`;
+            }
+            return `${genLabel} — Architecture unavailable`;
+          }
+
+          function formatFitness(value){
+            if(!Number.isFinite(value)){
+              return 'n/a';
+            }
+            return Math.round(value).toLocaleString();
+          }
+
+          function getHistorySelection(){
+            if(!train || !Array.isArray(train.bestByGeneration) || !train.bestByGeneration.length){
+              return null;
+            }
+            if(train.historySelection === null || train.historySelection < 0){
+              return null;
+            }
+            const capped = Math.min(train.bestByGeneration.length - 1, train.historySelection);
+            if(capped < 0){
+              return null;
+            }
+            return { entry: train.bestByGeneration[capped], index: capped };
+          }
+
+          function syncHistoryControls(){
+            if(!historySlider) return;
+            const total = train && Array.isArray(train.bestByGeneration) ? train.bestByGeneration.length : 0;
+            const hasHistory = total > 0;
+            historySlider.min = 0;
+            historySlider.max = total;
+            historySlider.step = 1;
+            const selection = train && train.historySelection !== null ? Math.max(0, Math.min(total - 1, train.historySelection)) : null;
+            const sliderValue = (selection !== null && hasHistory) ? selection + 1 : 0;
+            historySlider.value = String(sliderValue);
+            historySlider.disabled = !hasHistory;
+            if(hasHistory){
+              const fill = total > 0 ? Math.max(0, Math.min(100, (sliderValue / total) * 100)) : 0;
+              const active = 'rgba(141, 225, 173, 0.85)';
+              const base = 'rgba(94, 74, 227, 0.25)';
+              historySlider.style.background = `linear-gradient(90deg, ${active} 0%, ${active} ${fill}%, ${base} ${fill}%, ${base} 100%)`;
+            } else {
+              historySlider.style.background = 'linear-gradient(90deg, rgba(94, 74, 227, 0.35), rgba(141, 225, 173, 0.55))';
+            }
+
+            if(historyLabel){
+              if(!hasHistory || sliderValue === 0){
+                historyLabel.textContent = 'Live (current training)';
+              } else {
+                const entry = train.bestByGeneration[sliderValue - 1];
+                historyLabel.textContent = `Gen ${entry.gen}`;
+              }
+            }
+
+            if(historyMeta){
+              if(!hasHistory){
+                historyMeta.textContent = 'Best-of-generation snapshots will appear as training progresses.';
+              } else if(sliderValue === 0){
+                const latest = train.bestByGeneration[total - 1];
+                const info = [];
+                if(Number.isFinite(latest.gen)) info.push(`Latest stored: Gen ${latest.gen}`);
+                if(Number.isFinite(latest.fitness)) info.push(`Fitness ${formatFitness(latest.fitness)}`);
+                if(latest.modelType) info.push(latest.modelType.toUpperCase());
+                historyMeta.textContent = info.length ? info.join(' • ') : 'Snapshot details unavailable.';
+              } else {
+                const entry = train.bestByGeneration[sliderValue - 1];
+                const info = [];
+                if(entry.modelType) info.push(entry.modelType.toUpperCase());
+                if(Number.isFinite(entry.fitness)) info.push(`Fitness ${formatFitness(entry.fitness)}`);
+                historyMeta.textContent = info.length ? info.join(' • ') : 'Snapshot details unavailable.';
+              }
+            }
+          }
+
+          function recordGenerationSnapshot(snapshot){
+            if(!train) return;
+            if(!Array.isArray(train.bestByGeneration)){
+              train.bestByGeneration = [];
+            }
+            const prevLength = train.bestByGeneration.length;
+            train.bestByGeneration.push({
+              gen: snapshot.gen,
+              fitness: snapshot.fitness,
+              modelType: snapshot.modelType,
+              layerSizes: Array.isArray(snapshot.layerSizes) ? snapshot.layerSizes.slice() : null,
+              weights: snapshot.weights,
+              recordedAt: snapshot.recordedAt || Date.now(),
+            });
+            if(train.historySelection !== null){
+              const lastIdxBefore = Math.max(0, prevLength - 1);
+              if(prevLength === 0 || train.historySelection >= lastIdxBefore){
+                train.historySelection = train.bestByGeneration.length - 1;
+              }
+            }
+            syncHistoryControls();
           }
 
           function activeWeightArray(){
@@ -1976,6 +2179,8 @@
             bestFitness: -Infinity,
             bestEverFitness: -Infinity,
             bestEverWeights: null,
+            bestByGeneration: [],
+            historySelection: null,
             genNoImprove: 0,
             // exploration config
             heavyTailFrac: 0.25,
@@ -2003,6 +2208,7 @@
 
           train.scorePlotAxisMax = Math.max(10, Math.ceil(train.popSize * 1.2));
           train.scorePlotPending = 0;
+          syncHistoryControls();
 
           function updateTrainStatus(){
             if(trainStatus){
@@ -2013,21 +2219,51 @@
                 trainStatus.textContent = `Training stopped — Model: ${train.modelType.toUpperCase()} · Engine: ${engineLabel}`;
               }
             }
+            const historySelection = getHistorySelection();
+            const snapshot = historySelection ? historySelection.entry : null;
             let currentWeights = null;
-            if(train.currentWeightsOverride){
+            let overrideLayers = null;
+
+            if(snapshot){
+              currentWeights = snapshot.weights || null;
+              if(Array.isArray(snapshot.layerSizes) && snapshot.layerSizes.length >= 2){
+                overrideLayers = snapshot.layerSizes.slice();
+              } else if(snapshot.modelType === 'mlp'){
+                overrideLayers = currentMlpLayerSizes();
+              } else if(snapshot.modelType === 'linear'){
+                overrideLayers = [FEAT_DIM, 1];
+              }
+            } else if(train.currentWeightsOverride){
               currentWeights = train.currentWeightsOverride;
+              if(train.modelType === 'mlp'){
+                overrideLayers = currentMlpLayerSizes();
+              }
             } else if(train.enabled && train.candIndex >= 0 && train.candIndex < train.candWeights.length){
               currentWeights = train.candWeights[train.candIndex];
+              if(train.modelType === 'mlp'){
+                overrideLayers = currentMlpLayerSizes();
+              }
             } else if(train.mean){
               currentWeights = train.mean;
+              if(train.modelType === 'mlp'){
+                overrideLayers = currentMlpLayerSizes();
+              }
+            }
+
+            if(!snapshot && !currentWeights && train.bestEverWeights){
+              currentWeights = train.bestEverWeights;
+              overrideLayers = (train.modelType === 'mlp') ? currentMlpLayerSizes() : [FEAT_DIM, 1];
             }
 
             if(architectureEl){
-              architectureEl.textContent = describeModelArchitecture();
+              if(snapshot){
+                architectureEl.textContent = describeSnapshotArchitecture(snapshot);
+              } else {
+                architectureEl.textContent = describeModelArchitecture();
+              }
             }
             try {
-              const override = (train.modelType === 'mlp') ? currentMlpLayerSizes() : null;
-              renderNetworkD3(currentWeights, override);
+              renderNetworkD3(currentWeights, overrideLayers);
             } catch (_) {
               /* ignore render failures */
             }
@@ -2172,11 +2408,14 @@
             train.gameScores = [];
             train.gameModelTypes = [];
             train.phase = 'eval'; train.currentWeightsOverride = null; train.reevalDone = 0; train.reevalAccum = 0; train.reevalTarget = -1; train.bestFitness = -Infinity; train.bestEverFitness = -Infinity; train.bestEverWeights = null;
+            train.bestByGeneration = [];
+            train.historySelection = null;
             train.diversityScale = train.diversityBaseScale;
             train.randomRestartProb = train.randomRestartBaseProb;
             train.scorePlotPending = 0;
             train.scorePlotAxisMax = Math.max(10, Math.ceil(train.popSize * 1.2));
             updateScorePlot();
+            syncHistoryControls();
             updateTrainStatus();
             log('Training parameters reset');
           }
@@ -2239,8 +2478,18 @@
                   }
                   for(let d=0; d<dim; d++) newStd[d] = Math.max(train.minStd, Math.min(train.maxStd, Math.sqrt(newStd[d])));
                   const bestThisGen = train.candScores[idx[0]];
+                  const layerSnapshot = (train.modelType === 'mlp') ? currentMlpLayerSizes() : [FEAT_DIM, 1];
+                  const snapshotWeights = cloneWeightsArray(bestW);
+                  recordGenerationSnapshot({
+                    gen: train.gen + 1,
+                    fitness: bestThisGen,
+                    modelType: train.modelType,
+                    layerSizes: layerSnapshot,
+                    weights: snapshotWeights,
+                  });
                   if(bestThisGen > (train.bestEverFitness ?? -Infinity)){
-                    train.bestEverFitness = bestThisGen; train.bestEverWeights = new Float64Array(train.candWeights[idx[0]]);
+                    train.bestEverFitness = bestThisGen;
+                    train.bestEverWeights = snapshotWeights;
                   }
                   if(bestThisGen > train.bestFitness){
                     for(let d=0; d<newStd.length; d++){
@@ -3376,6 +3625,29 @@
               };
               reader.readAsText(file);
             });
+          }
+
+          const handleHistorySliderInput = () => {
+            if(!historySlider || !train){
+              return;
+            }
+            if(!Array.isArray(train.bestByGeneration) || train.bestByGeneration.length === 0){
+              train.historySelection = null;
+            } else {
+              const raw = Number(historySlider.value);
+              if(!Number.isFinite(raw) || raw <= 0){
+                train.historySelection = null;
+              } else {
+                const idx = Math.min(train.bestByGeneration.length - 1, Math.max(0, Math.round(raw) - 1));
+                train.historySelection = idx;
+              }
+            }
+            syncHistoryControls();
+            updateTrainStatus();
+          };
+          if(historySlider){
+            historySlider.addEventListener('input', handleHistorySliderInput);
+            historySlider.addEventListener('change', handleHistorySliderInput);
           }
 
           // Hook up training buttons


### PR DESCRIPTION
## Summary
- add a styled model history slider beneath the network visualization so the saved generations are easy to scrub through
- persist the best model from each generation and drive the visualization/metadata from the selected snapshot

## Testing
- not run (front-end change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca6c25f6f08322bfbd7b3c63be0ff4