### PR TITLE
Guard tetris well feature behind solid stack

### DIFF
--- a/src/tetris/features.py
+++ b/src/tetris/features.py
@@ -161,6 +161,7 @@ def features_from_grid(grid: GridLike, lines: int) -> list[float]:
     bump = bumpiness(heights)
     max_height = max(heights) if heights else 0
     wells = well_metrics(heights)
+    tetris_well_depth = wells.tetris_well if holes == 0 else 0
     contact = contact_area(grid)
     row_trans = row_transitions(grid)
     col_trans = col_transitions(grid)
@@ -175,7 +176,7 @@ def features_from_grid(grid: GridLike, lines: int) -> list[float]:
     s_max_h = max_height / HEIGHT if HEIGHT else 0.0
     s_well = wells.well_sum / denom_area
     s_edge = wells.edge_well / HEIGHT if HEIGHT else 0.0
-    s_tetris = wells.tetris_well / HEIGHT if HEIGHT else 0.0
+    s_tetris = tetris_well_depth / HEIGHT if HEIGHT else 0.0
     s_contact = contact / (WIDTH * HEIGHT * 2) if WIDTH and HEIGHT else 0.0
     s_row = row_trans / denom_area
     s_col = col_trans / denom_area

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -22,3 +22,23 @@ def test_tetris_well_positive_for_single_deep_well() -> None:
     expected = depth / Board.height
     assert features[idx] == pytest.approx(expected)
     assert features[idx] > 0
+
+
+def test_tetris_well_zero_when_other_holes_present() -> None:
+    board = Board()
+    well_col = 2
+    depth = 5
+    start_row = Board.height - depth
+
+    for row in range(start_row, Board.height):
+        for col in range(Board.width):
+            if col == well_col:
+                continue
+            board.set_cell(row, col, 1)
+
+    hole_row = start_row + 1
+    board.set_cell(hole_row, 0, 0)
+
+    features = features_from_grid(board.grid, lines=0)
+    idx = FEATURE_NAMES.index("Tetris Well")
+    assert features[idx] == pytest.approx(0.0)

--- a/web/index.html
+++ b/web/index.html
@@ -2977,7 +2977,10 @@
                 aggH += v;
                 if(v > maxH) maxH = v;
               }
-              const {wellSum, edgeWell, tetrisWell} = wellMetrics(h);
+              let {wellSum, edgeWell, tetrisWell} = wellMetrics(h);
+              if(Holes > 0){
+                tetrisWell = 0;
+              }
               const Contact = contactArea(g);
               const rT = rowTransitions(g);
               const cT = colTransitions(g);
@@ -3003,7 +3006,10 @@
                 aggH += v;
                 if(v > maxH) maxH = v;
               }
-              const {wellSum, edgeWell, tetrisWell} = wellMetrics(heights);
+              let {wellSum, edgeWell, tetrisWell} = wellMetrics(heights);
+              if(Holes > 0){
+                tetrisWell = 0;
+              }
               const Contact = contactAreaFromRows(rows);
               const rT = rowTransitionsFromRows(rows);
               const cT = columnTransitionsFromRows(rows);


### PR DESCRIPTION
## Summary
- guard the Python feature extraction so the Tetris Well depth is ignored when other columns contain holes
- mirror the guard in the browser feature extraction helpers to keep parity with the Python vector
- add a regression test that injects a hole away from the well and expects the Tetris Well feature to be zero

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca715c66a08322a02ff34c7c297ed4