### PR TITLE
Center sidebar stack on small screens

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -381,11 +381,11 @@
       <div class="game relative flex w-full max-w-5xl flex-col items-center gap-10">
         <div class="flex w-full max-w-5xl flex-col items-center gap-4 md:flex-row md:items-start md:justify-center md:gap-6">
           <canvas id="canvas" width="300" height="600" tabindex="0" class="shadow-glow"></canvas>
-          <div class="flex w-full max-w-sm flex-col items-start gap-6 md:w-auto md:items-start md:gap-8">
-            <div class="flex flex-col items-start gap-3 md:items-start">
+          <div class="flex w-full max-w-sm flex-col items-center gap-6 md:w-auto md:items-start md:gap-8">
+            <div class="flex flex-col items-center gap-3 md:items-start">
               <canvas id="preview" width="140" height="140" class="h-[140px] w-[140px]"></canvas>
             </div>
-            <div class="flex flex-col items-start gap-2 md:items-start md:text-left">
+            <div class="flex flex-col items-center gap-2 md:items-start md:text-left">
               <div id="level" class="text-xs uppercase tracking-[0.45em] text-plum/70">Level: 0</div>
               <div
                 id="score"


### PR DESCRIPTION
## Summary
- update the sidebar stack to center its content on small screens while keeping the desktop alignment unchanged
- center the preview and score sections by default so they align under the playfield on narrow viewports

## Testing
- Viewed `web/index.html` in a mobile-width browser window

------
https://chatgpt.com/codex/tasks/task_e_68ca748fe5c48322abbd50fb1f896e65