### PR TITLE
Allow Tailwind CDN runtime through CSP

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline' https://pyscript.net https://fonts.googleapis.com; connect-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://fonts.googleapis.com https://fonts.gstatic.com data: blob:; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;"
+      content="default-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io; style-src 'self' 'unsafe-inline' https://pyscript.net https://fonts.googleapis.com; connect-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io https://fonts.googleapis.com https://fonts.gstatic.com data: blob:; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;"
     />
     <title>Tetris</title>
     <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.18.0/dist/tf.min.js"></script>


### PR DESCRIPTION
## Summary
- allow the Tailwind CDN runtime host in the Content-Security-Policy so the Tailwind utilities load correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca76db6d3c832294ca942e67e750cd