### PR TITLE
Remove plateau-triggered training adjustments

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1786,7 +1786,6 @@
               train.gen = snapGen;
             }
             train.bestFitness = train.bestEverFitness;
-            train.genNoImprove = 0;
 
             updateTrainStatus();
 
@@ -2190,12 +2189,9 @@
             bestEverWeights: null,
             bestByGeneration: [],
             historySelection: null,
-            genNoImprove: 0,
             // exploration config
             heavyTailFrac: 0.25,
             heavyTailScale: 3.0,
-            plateauGens: 8,
-            stdBoost: 1.8,
             diversityFrac: 0.3,
             diversityScale: 4.0,
             diversityBaseScale: 4.0,
@@ -2408,7 +2404,6 @@
             train.mean = initialMean(train.modelType);
             train.std = initialStd(train.modelType);
             train.gen = 0;
-            train.genNoImprove = 0;
             train.candWeights = [];
             train.candScores = [];
             train.candIndex = -1;
@@ -2520,41 +2515,15 @@
                     for(let d=0; d<newStd.length; d++){
                       newStd[d] = Math.max(train.minStd, newStd[d] * 0.85);
                     }
-                    const prevDiversityScale = train.diversityScale;
-                    const prevRestartProb = train.randomRestartProb;
-                    const baseDiversityScale = train.diversityBaseScale ?? prevDiversityScale;
+                    const baseDiversityScale = train.diversityBaseScale ?? train.diversityScale;
                     const minDiversityScale = train.diversityMinScale ?? baseDiversityScale;
                     const maxDiversityScale = train.diversityMaxScale ?? baseDiversityScale;
-                    const baseRestartProb = train.randomRestartBaseProb ?? prevRestartProb;
+                    const baseRestartProb = train.randomRestartBaseProb ?? train.randomRestartProb;
                     const minRestartProb = train.randomRestartMin ?? baseRestartProb;
                     const maxRestartProb = train.randomRestartMax ?? baseRestartProb;
                     train.diversityScale = Math.min(maxDiversityScale, Math.max(minDiversityScale, baseDiversityScale));
                     train.randomRestartProb = Math.min(maxRestartProb, Math.max(minRestartProb, baseRestartProb));
-                    if(prevDiversityScale !== train.diversityScale || prevRestartProb !== train.randomRestartProb){
-                      log(
-                        `Progress resumed: exploration reset — diversity scale -> ${train.diversityScale.toFixed(2)}, restart mix -> ${(train.randomRestartProb * 100).toFixed(0)}%`
-                      );
-                    }
                     train.bestFitness = bestThisGen;
-                    train.genNoImprove = 0;
-                  } else {
-                    train.genNoImprove += 1;
-                    if(train.genNoImprove >= train.plateauGens){
-                      for(let d=0; d<newStd.length; d++){
-                        newStd[d] = Math.min(train.maxStd, newStd[d] * train.stdBoost);
-                      }
-                      train.genNoImprove = 0;
-                      let plateauMsg = 'Plateau detected: boosted exploration std';
-                      if(train.diversityScale < train.diversityMaxScale){
-                        train.diversityScale = Math.min(train.diversityMaxScale, train.diversityScale * train.diversityBoost);
-                        plateauMsg += `, diversity scale -> ${train.diversityScale.toFixed(2)}`;
-                      }
-                      if(train.randomRestartProb < train.randomRestartMax){
-                        train.randomRestartProb = Math.min(train.randomRestartMax, train.randomRestartProb + train.randomRestartStep);
-                        plateauMsg += `, restart mix -> ${(train.randomRestartProb * 100).toFixed(0)}%`;
-                      }
-                      log(plateauMsg);
-                    }
                   }
                   train.mean = newMean; train.std = newStd; train.gen += 1; log(`Gen ${train.gen} complete. Best fitness: ${bestThisGen}`);
                   samplePopulation();


### PR DESCRIPTION
## Summary
- remove plateau tracking fields from the training configuration/state
- simplify the generation update to drop plateau detection while keeping generation reseeding

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca892e77c883228bbd65bac394ffd6