### PR TITLE
Simplify AI placement planning to single ply

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1345,8 +1345,6 @@
           ];
           const FEAT_DIM = FEATURE_NAMES.length;
           const AI_STEP_MS = 28; // ms between AI animation steps
-          const LOOKAHEAD_LAMBDA = 0.7; // weight for next-piece lookahead score
-          const LOOKAHEAD_BEAM = 6; // evaluate next-piece lookahead only for top-K first moves
 
           // MLP architecture (when selected)
           const DEFAULT_MLP_HIDDEN = [8];
@@ -2831,48 +2829,21 @@
             return outputScratch[0] + bias;
           }
           function scoreFeats(weights, feats){ return (train.modelType === 'mlp') ? mlpScore(weights, feats) : dot(weights, feats); }
-          function choosePlacement2(weights, grid, curShape, nextShape){
-            return trainingProfiler.section('train.plan.lookahead', () => {
+          function choosePlacement2(weights, grid, curShape){
+            return trainingProfiler.section('train.plan.single', () => {
               const acts = enumeratePlacements(grid, curShape);
               if(acts.length === 0) return null;
-              let best = acts[0];
-              let bestS = -Infinity;
-              const sims = [];
-              // precompute first-ply sims and scores
+              let best = null;
+              let bestScore = -Infinity;
+              // Evaluate each valid placement exactly once.
               for(const a of acts){
                 const sim = simulateAfterPlacement(grid, curShape, a.rot, a.col);
                 if(!sim) continue;
                 const baseFeats = featuresFromGrid(sim.grid, sim.lines);
-                const s1 = scoreFeats(weights, baseFeats);
-                sims.push({ a, sim, s1 });
-              }
-              if(sims.length === 0) return null;
-              // Beam: consider lookahead only for top-K first-ply moves
-              sims.sort((u, v) => v.s1 - u.s1);
-              const K = Math.min(LOOKAHEAD_BEAM, sims.length);
-              const acts2Cache = new WeakMap();
-              for(let i=0; i<sims.length; i++){
-                let s = sims[i].s1;
-                if(nextShape && i < K){
-                  let acts2 = acts2Cache.get(sims[i].sim.grid);
-                  if(!acts2){
-                    acts2 = enumeratePlacements(sims[i].sim.grid, nextShape);
-                    acts2Cache.set(sims[i].sim.grid, acts2);
-                  }
-                  if(acts2.length > 0){
-                    let best2 = -Infinity;
-                    for(const a2 of acts2){
-                      const ff2 = featuresForPlacement(sims[i].sim.grid, nextShape, a2.rot, a2.col);
-                      if(!ff2) continue;
-                      const s2 = scoreFeats(weights, ff2.feats);
-                      if(s2 > best2) best2 = s2;
-                    }
-                    if(Number.isFinite(best2)) s += LOOKAHEAD_LAMBDA * best2;
-                  }
-                }
-                if(s > bestS){
-                  bestS = s;
-                  best = sims[i].a;
+                const score = scoreFeats(weights, baseFeats);
+                if(score > bestScore){
+                  bestScore = score;
+                  best = a;
                 }
               }
               return best;
@@ -2882,7 +2853,8 @@
             return trainingProfiler.section('train.plan', () => {
               if(!state.active) return null;
               const w = train.currentWeightsOverride || train.candWeights[train.candIndex] || train.mean;
-              const placement = choosePlacement2(w, state.grid, state.active.shape, state.next);
+              // Single-ply evaluation selects the best placement for the current piece.
+              const placement = choosePlacement2(w, state.grid, state.active.shape);
               if(!placement){
                 return null;
               }


### PR DESCRIPTION
## Summary
- remove unused lookahead constants from the web UI configuration
- simplify `choosePlacement2` to evaluate placements once with a single-ply profiler label
- update `planForCurrentPiece` to call the new single-ply evaluation helper and document the approach

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca8c0e6a0c83229a3f9b42356997aa