### PR TITLE
Handle missing candidate score arrays during training

### DIFF
--- a/web/js/training.js
+++ b/web/js/training.js
@@ -1226,6 +1226,19 @@ export function initTraining(game, renderer) {
           log(`Candidate ${train.candIndex+1}/${train.popSize} (gen ${train.gen+1})`);
           updateTrainStatus();
         } else {
+          if(!Array.isArray(train.candScores) || train.candScores.length === 0){
+            log('Candidate score buffer missing or empty. Reinitializing population.');
+            samplePopulation();
+            train.candIndex = 0;
+            Object.assign(state,{grid:emptyGrid(),active:null,next:null,score:0, level:0, pieces:0});
+            state.gravity = gravityForLevel(0);
+            updateLevel(); updateScore();
+            spawn(); train.ai.plan = null; train.ai.acc = 0;
+            updateScorePlot();
+            log(`Candidate ${train.candIndex+1}/${train.popSize} (gen ${train.gen+1})`);
+            updateTrainStatus();
+            return;
+          }
           const idx = [...train.candScores.keys()].sort((a,b)=>train.candScores[b]-train.candScores[a]);
           const bestIdx = idx[0];
           const bestThisGen = train.candScores[bestIdx];


### PR DESCRIPTION
## Summary
- add a guard before sorting candidate scores to ensure the buffer exists and has entries
- log a diagnostic, resample the population, and reset the board when candidate scores are unavailable

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68caa937f5e483228e9e3e7366e123a9