### PR TITLE
Allow Tailwind inline styles under CSP

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,9 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Allow Tailwind CDN runtime to inject its inline stylesheet for utility classes -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io data: blob:; script-src 'self' 'unsafe-eval' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io; style-src 'self' https://pyscript.net https://fonts.googleapis.com; connect-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io https://fonts.googleapis.com https://fonts.gstatic.com data: blob:; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;"
+      content="default-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io data: blob:; script-src 'self' 'unsafe-eval' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io; style-src 'self' 'unsafe-inline' https://pyscript.net https://fonts.googleapis.com; connect-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io https://fonts.googleapis.com https://fonts.gstatic.com data: blob:; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;"
     />
     <title>Tetris</title>
     <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.18.0/dist/tf.min.js"></script>


### PR DESCRIPTION
## Summary
- document why the page needs to allow Tailwind's inline stylesheet
- relax the CSP style-src directive to include 'unsafe-inline' so Tailwind CDN utilities render again

## Testing
- python -m http.server 8000 # manual visual verification

------
https://chatgpt.com/codex/tasks/task_e_68caaea3912c832290debac8a08b7b23