### PR TITLE
Simplify placement enumeration to avoid redundant drop simulation

### DIFF
--- a/web/js/training.js
+++ b/web/js/training.js
@@ -1345,15 +1345,6 @@ export function initTraining(game, renderer) {
     }
     function dropRowSim(grid, piece){ if(!canMove(grid,piece,0,0)) return null; while(canMove(grid,piece,0,1)) piece.move(0,1); return piece.row; }
 
-    // Return true if dropRowSim finds a valid landing row for the given rotation and column.
-    function pathClear(grid, shape, rot, col){
-      const piece = new Piece(shape);
-      piece.rot = rot;
-      piece.row = 0;
-      piece.col = col;
-      return dropRowSim(grid, piece) !== null;
-    }
-
     function enumeratePlacements(grid, shape){
       return trainingProfiler.section('train.full.enumerate', () => {
         const actions = [];
@@ -1361,9 +1352,7 @@ export function initTraining(game, renderer) {
         for(const rot of rotIdx){
           const width = stateWidth(SHAPES[shape][rot]);
           for(let col=0; col<=WIDTH-width; col++){
-            if(pathClear(grid, shape, rot, col)){
-              actions.push({ rot, col });
-            }
+            actions.push({ rot, col });
           }
         }
         return actions;


### PR DESCRIPTION
## Summary
- push every rotation/column combination directly during placement enumeration
- remove the unused pathClear helper and its per-call Piece allocation

## Testing
- not run (requires browser-based headless training mode)


------
https://chatgpt.com/codex/tasks/task_e_68cac3d11d3c8322a78a69eeada6c67a