### PR TITLE
Add new holes feature to heuristic evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ the codebase focused on the shipped experience.
 
 - Each candidate move is scored by simulating the resulting board and computing
   handcrafted features: cleared-line count, indicator flags for singles through
-  tetrises, normalized hole count, column bumpiness, maximum stack height,
-  well depth, edge wells, contact area, row/column transitions, and aggregate
-  height.
+  tetrises, normalized hole count, newly created holes, column bumpiness,
+  maximum stack height, well depth, edge wells, contact area, row/column
+  transitions, and aggregate height.
 - Policies can be linear or a tiny one-hidden-layer MLP (ReLU activations). Both
-  operate on the 15-dimensional feature vector; the MLP runs with hand-written
+  operate on the 17-dimensional feature vector; the MLP runs with hand-written
   matrix multiplies to avoid tf.js overhead during search.
 - A shallow beam-search lookahead (depth 1 with next-piece preview) combines the
   immediate feature score with a discounted estimate (`λ = 0.7`) of the best

--- a/web/index.html
+++ b/web/index.html
@@ -231,6 +231,10 @@
               <dd class="text-sm text-plum/80">Fraction of empty cells trapped beneath blocks within each column.</dd>
             </div>
             <div>
+              <dt class="font-semibold text-shell">New Holes</dt>
+              <dd class="text-sm text-plum/80">Portion of newly created trapped cells compared to the pre-move board.</dd>
+            </div>
+            <div>
               <dt class="font-semibold text-shell">Bumpiness</dt>
               <dd class="text-sm text-plum/80">Normalized sum of height differences between adjacent columns.</dd>
             </div>


### PR DESCRIPTION
## Summary
- add a "New Holes" heuristic that measures additional trapped cells after each simulated placement and feed it into the scorer
- update baseline weights and board analysis helpers to work with the expanded 17-feature vector
- document and surface the new feature in the site copy alongside the existing hole metric

## Testing
- not run (no automated test suite provided)


------
https://chatgpt.com/codex/tasks/task_e_68cae6dfa3908322bb57afe312107d84