### PR TITLE
Add new holes feature to training evaluation

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -231,6 +231,10 @@
               <dd class="text-sm text-plum/80">Fraction of empty cells trapped beneath blocks within each column.</dd>
             </div>
             <div>
+              <dt class="font-semibold text-shell">New Holes</dt>
+              <dd class="text-sm text-plum/80">Share of holes introduced by the placement after clearing any lines.</dd>
+            </div>
+            <div>
               <dt class="font-semibold text-shell">Bumpiness</dt>
               <dd class="text-sm text-plum/80">Normalized sum of height differences between adjacent columns.</dd>
             </div>


### PR DESCRIPTION
## Summary
- add a dedicated "New Holes" feature to the AI feature vector and expose its description in the UI
- track cleared rows during simulation so we can compare column hole masks before and after a move
- adjust placement evaluation to compute baseline hole counts and feed the new feature when scoring moves

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68caeff2af7c832286a69e3b8df58d12