### PR TITLE
Add GitHub fork banner to landing page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -23,6 +23,21 @@
 
   </head>
   <body class="relative min-h-screen overflow-x-hidden font-body antialiased text-shell">
+    <a
+      class="github-link"
+      href="https://github.com/kjeeetil/tetris"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Fork this project on GitHub"
+    >
+      <svg class="github-link__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          fill="currentColor"
+          d="M12 .5a12 12 0 0 0-3.79 23.4c.6.11.82-.26.82-.58v-2.23c-3.34.72-4.04-1.61-4.04-1.61-.55-1.4-1.34-1.77-1.34-1.77-1.09-.74.08-.72.08-.72 1.2.08 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.31-5.47-1.33-5.47-5.91 0-1.31.47-2.39 1.24-3.23-.13-.31-.54-1.56.12-3.25 0 0 1.01-.32 3.3 1.23a11.53 11.53 0 0 1 6 0c2.3-1.55 3.3-1.23 3.3-1.23.66 1.69.25 2.94.12 3.25.77.84 1.24 1.92 1.24 3.23 0 4.6-2.81 5.59-5.49 5.89.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.82.58A12 12 0 0 0 12 .5Z"
+        />
+      </svg>
+      <span class="github-link__text">Fork me on GitHub</span>
+    </a>
     <div class="aura-shape aura-shape--1"></div>
     <div class="aura-shape aura-shape--2"></div>
     <div class="aura-shape aura-shape--3"></div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -27,6 +27,55 @@ body::before {
   mix-blend-mode: screen;
   z-index: -2;
 }
+.github-link {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  z-index: 30;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(249, 245, 255, 0.22);
+  background: linear-gradient(135deg, rgba(94, 74, 227, 0.45), rgba(244, 247, 121, 0.35));
+  color: #f9f5ff;
+  font-family: "Instrument Serif", serif;
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: none;
+  box-shadow: 0 18px 36px rgba(17, 17, 31, 0.34);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+.github-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 42px rgba(17, 17, 31, 0.4);
+}
+.github-link:focus-visible {
+  outline: 2px solid rgba(244, 247, 121, 0.65);
+  outline-offset: 3px;
+}
+.github-link__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+.github-link__text {
+  font-weight: 600;
+}
+@media (max-width: 640px) {
+  .github-link {
+    top: 16px;
+    right: 16px;
+    padding: 0.45rem 1rem;
+    font-size: 12px;
+  }
+  .github-link__icon {
+    width: 18px;
+    height: 18px;
+  }
+}
 .aura-shape {
   position: absolute;
   border-radius: 48px;


### PR DESCRIPTION
## Summary
- add a persistent "Fork me on GitHub" call-to-action linking to the repository
- style the link to match the site's aesthetic and remain usable on small screens

## Testing
- not run (static site changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cbc11c5d608322b8a54eae4ac57707