### PR TITLE
Prevent canvas focus from scrolling page

### DIFF
--- a/web/js/game-loop.js
+++ b/web/js/game-loop.js
@@ -205,7 +205,12 @@ export function createGame(dom, renderer) {
       return;
     }
     if (canvas && typeof canvas.focus === 'function') {
-      canvas.focus();
+      try {
+        // Prevent the focus call from forcing the page to scroll back to the canvas.
+        canvas.focus({ preventScroll: true });
+      } catch (err) {
+        canvas.focus();
+      }
     }
     state.grid = emptyGrid();
     state.score = 0;


### PR DESCRIPTION
## Summary
- keep the main canvas focused without forcing the page to scroll back to the top
- fall back to the original focus call when the browser does not support preventScroll

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbe19cecac83229c314beb8db7a27f