### PR TITLE
Add raw occupancy MLP policy option

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -88,7 +88,8 @@
           <label for="model-select" class="text-xs uppercase tracking-[0.35em] text-plum/70">Model:</label>
           <select id="model-select" class="bg-transparent text-base font-display">
             <option value="linear" selected>Linear (ES)</option>
-            <option value="mlp">MLP (tf.js)</option>
+            <option value="mlp">MLP (engineered features)</option>
+            <option value="mlp_raw">MLP (board occupancy)</option>
           </select>
           <label
             id="render-toggle-label"


### PR DESCRIPTION
## Summary
- add a third policy option that drives an MLP from the raw 10×20 board occupancy vector
- extend the training pipeline to extract raw features, score the new model type, and persist metadata in snapshots and the UI
- update the model selector and status displays to reflect the additional architecture

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cbe844ae388322b1ff0e78b6f9d080