### PR TITLE
Refresh README to document modular front-end layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,70 @@
 ## Overview
 
 This project packages a playable Tetris clone together with a lightweight
-reinforcement-learning lab. The web front end renders the game with
-vanilla JavaScript and HTML canvas while exposing controls that let you train
-heuristic agents directly in the browser. All gameplay and learning logic runs
-in JavaScript.
+reinforcement-learning lab. The web front end still renders the game with
+vanilla JavaScript and HTML canvas, but the gameplay, rendering, and training
+logic now live in dedicated ES modules under `web/js/`. The `index.html` file is
+a slim shell that stitches those modules together, keeping the experience
+bundler-free while making the codebase easier to navigate.
 
-## Site build-up
+## Project layout
 
-### Front-end stack
+### Web front end
 
-- Single-page application served from `web/index.html` with no build tooling –
-  all styling and layout use Tailwind via CDN, plus Google Fonts for typography.
+- `web/index.html` – Static markup, analytics panels, and script/style tags that
+  load the rest of the client without a build step.
+- `web/styles.css` – Custom gradients, layout polish, and component styling that
+  complement Tailwind utility classes.
+- `web/tailwind-config.js` – Runtime configuration passed to the CDN Tailwind
+  loader so typography and the colour palette stay consistent across modules.
+- `web/js/constants.js` – Shared board dimensions, drop timings, colour tokens,
+  and other configuration flags.
+- `web/js/engine.js` – `Piece` class plus pure helpers for bag randomisation,
+  collision tests, gravity lookups, locking pieces, and clearing rows.
+- `web/js/rendering.js` – Canvas rendering pipeline, responsive board scaling,
+  HUD updates, and diagnostics logging.
+- `web/js/game-loop.js` – Input handling, pause/play state machine, watchdog,
+  scoring logic, and the hooks that let the trainer drive the game.
+- `web/js/training.js` – Evolution-strategy trainer, weight persistence,
+  snapshot history slider, TensorFlow.js integration, and the UI wiring for the
+  model controls.
+
+### Infrastructure
+
+- `Dockerfile` – Builds the static site into an Nginx image for easy hosting.
+- `cloudbuild.yaml` – Sample Cloud Build recipe that uses the Dockerfile to
+  publish the site.
+
+## Front-end stack
+
+- Modular ES modules loaded directly in the browser; no bundler or transpiler is
+  required for development.
+- Tailwind CSS served via CDN with a minimal runtime config, plus handcrafted
+  CSS for the neon glassmorphism aesthetic.
 - Canvas-based renderer backed by a compact `Piece` class and board helpers for
   locking, row clearing, previews, and scoring updates.
 - Optional visualisations supplied by D3.js (for network diagrams) and the
   Canvas API (for score charts and diagnostics).
-- TensorFlow.js is loaded for experimentation with neural policies; the default
+- TensorFlow.js is available for experimenting with neural policies; the default
   inference path keeps evaluation in plain JavaScript for performance.
 
-### Layout and interaction flow
+## Layout and interaction flow
 
-- The main column hosts the playfield canvas, next-piece preview, level and score
-  readouts, and tactile play/reset buttons.
-- A second control strip enables AI-specific actions: start/stop training,
-  reset evolution, pick between linear or MLP models, toggle headless training,
-  and throttle evaluation speed.
-- Analytics panels underneath render the scatter plot of per-game scores, an
-  interactive network graph of the active policy, and a rolling diagnostics log
-  that captures watchdog resets, training events, and game-over messages.
+- **Main play surface** – The central column holds the game canvas, next-piece
+  preview, and live level/score readouts. Manual play uses the keyboard
+  (arrow keys to move, `↑` to rotate, `Space` to hard drop) and on-screen play
+  and reset buttons.
+- **Game pacing controls** – A speed slider scales the gravity delay, while the
+  toggle button can pause/resume whether the AI or a human is in control.
+- **Training console** – Buttons launch or stop evolutionary training, reset the
+  search distribution, switch between linear and MLP policies, toggle headless
+  training renders, and manage weight import/export.
+- **Model configuration** – When the MLP policy is selected, a dedicated panel
+  exposes hidden-layer counts and per-layer width selectors. A history slider
+  lets you revisit best-of-generation snapshots, and status text tracks the
+  active generation alongside timing stats.
+- **Analytics** – Score history plots, a network graph, and a rolling diagnostics
+  log capture watchdog events, game overs, and trainer telemetry.
 
 ## Gameplay and engine mechanics
 
@@ -70,14 +106,17 @@ in JavaScript.
 
 ## Running the site
 
-1. Open `web/index.html` directly in any modern browser; no build or bundler is
-   required.
-2. Click **Start** to begin a manual game. Arrow keys move, **Up** rotates,
-   **Space** hard drops.
-3. Use the AI control buttons to launch evolutionary training, switch models,
-   or toggle headless evaluation.
+1. From the repository root, change into the `web/` directory.
+2. Serve the directory with any static web server (for example,
+   `python3 -m http.server 8000`). Using HTTP avoids module-loading and
+   Content-Security-Policy issues that can appear when opening files directly.
+3. Visit `http://localhost:8000` in a modern browser, start the game, and use the
+   control clusters to play manually or launch the trainer.
 
 ## Further exploration
 
 - The code is intentionally modular: extend the feature vector, plug in tf.js
   optimisers, or swap the fitness shaping logic to explore alternate heuristics.
+- Because the modules are decoupled, you can experiment with new renderers or
+  game inputs by editing `rendering.js` and `game-loop.js` without touching the
+  trainer internals.


### PR DESCRIPTION
## Summary
- describe the modular ES module structure introduced by splitting `index.html` into separate assets
- document the responsibilities of the new JavaScript modules, Tailwind config, and supporting files
- update usage guidance so the README reflects the new static-server workflow for modules

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cbed8dbf4c8322800d133c9cda0e07