### PR TITLE
Load TensorFlow.js dynamically before bootstrapping

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,6 @@
       content="default-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io data: blob:; script-src 'self' 'unsafe-eval' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io; style-src 'self' 'unsafe-inline' https://pyscript.net https://fonts.googleapis.com; connect-src 'self' https://pyscript.net https://cdn.jsdelivr.net https://cdn.tailwindcss.com https://ga.jspm.io https://fonts.googleapis.com https://fonts.gstatic.com data: blob:; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;"
     />
     <title>Tetris</title>
-    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.18.0/dist/tf.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/web/js/loader.js
+++ b/web/js/loader.js
@@ -1,0 +1,63 @@
+const TENSORFLOW_SRC = 'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.18.0/dist/tf.min.js';
+
+let tensorflowLoadPromise = null;
+
+export async function ensureTensorFlowLoaded() {
+  if (typeof window === 'undefined') {
+    throw new Error('TensorFlow.js can only be loaded in a browser environment.');
+  }
+
+  if (window.tf) {
+    return window.tf;
+  }
+
+  if (tensorflowLoadPromise) {
+    return tensorflowLoadPromise;
+  }
+
+  tensorflowLoadPromise = new Promise((resolve, reject) => {
+    let script = document.querySelector(`script[src="${TENSORFLOW_SRC}"]`);
+
+    const handleLoad = (event) => {
+      const target = event?.currentTarget ?? script;
+      if (target) {
+        target.dataset.tensorflowLoaderLoaded = 'true';
+      }
+
+      if (window.tf) {
+        resolve(window.tf);
+      } else {
+        const error = new Error('TensorFlow.js loaded but window.tf is unavailable.');
+        console.error(error);
+        tensorflowLoadPromise = null;
+        reject(error);
+      }
+    };
+
+    const handleError = (event) => {
+      console.error('Failed to load TensorFlow.js from CDN.', event);
+      tensorflowLoadPromise = null;
+      reject(new Error('Failed to load TensorFlow.js from CDN.'));
+    };
+
+    if (!script) {
+      script = document.createElement('script');
+      script.src = TENSORFLOW_SRC;
+      script.async = true;
+      script.dataset.tensorflowLoader = 'true';
+      script.addEventListener('load', handleLoad, { once: true });
+      script.addEventListener('error', handleError, { once: true });
+      document.head.appendChild(script);
+    } else {
+      script.dataset.tensorflowLoader = script.dataset.tensorflowLoader ?? 'true';
+      script.addEventListener('load', handleLoad, { once: true });
+      script.addEventListener('error', handleError, { once: true });
+
+      if (script.dataset.tensorflowLoaderLoaded === 'true' || script.readyState === 'complete') {
+        handleLoad();
+      }
+    }
+  });
+
+  return tensorflowLoadPromise;
+}

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,17 +1,28 @@
+import { ensureTensorFlowLoaded } from './loader.js';
 import { createRenderer } from './rendering.js';
 import { createGame } from './game-loop.js';
 import { initTraining } from './training.js';
 
-const canvas = document.getElementById('canvas');
-const preview = document.getElementById('preview');
-const diagnostics = document.getElementById('diagnostics');
-const scoreEl = document.getElementById('score');
-const levelEl = document.getElementById('level');
-const toggleBtn = document.getElementById('toggle');
-const resetBtn = document.getElementById('reset');
-const speedSlider = document.getElementById('speed');
-const speedDisplay = document.getElementById('speed-display');
+async function bootstrap() {
+  try {
+    await ensureTensorFlowLoaded();
 
-const renderer = createRenderer({ canvas, preview, diagnostics, scoreEl, levelEl });
-const game = createGame({ canvas, toggleBtn, resetBtn, speedSlider, speedDisplay }, renderer);
-initTraining(game, renderer);
+    const canvas = document.getElementById('canvas');
+    const preview = document.getElementById('preview');
+    const diagnostics = document.getElementById('diagnostics');
+    const scoreEl = document.getElementById('score');
+    const levelEl = document.getElementById('level');
+    const toggleBtn = document.getElementById('toggle');
+    const resetBtn = document.getElementById('reset');
+    const speedSlider = document.getElementById('speed');
+    const speedDisplay = document.getElementById('speed-display');
+
+    const renderer = createRenderer({ canvas, preview, diagnostics, scoreEl, levelEl });
+    const game = createGame({ canvas, toggleBtn, resetBtn, speedSlider, speedDisplay }, renderer);
+    initTraining(game, renderer);
+  } catch (error) {
+    console.error('Failed to bootstrap application.', error);
+  }
+}
+
+bootstrap();


### PR DESCRIPTION
## Summary
- add a loader utility that injects the TensorFlow.js CDN script once and surfaces load failures
- await the loader before creating the renderer, game, and training modules so TensorFlow is ready
- remove the hard-coded TensorFlow script tag from index.html now that it is injected dynamically

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc1c1888e483228f4a60c5cf4a740d