### PR TITLE
Add AlphaTetris option and update training descriptors

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -89,6 +89,7 @@
             <option value="linear" selected>Linear (ES)</option>
             <option value="mlp">MLP (engineered features)</option>
             <option value="mlp_raw">MLP (board occupancy)</option>
+            <option value="alphatetris">AlphaTetris (ConvNet)</option>
           </select>
           <label
             id="render-toggle-label"


### PR DESCRIPTION
## Summary
- add the AlphaTetris ConvNet option to the model selector
- teach the training UI helpers about the new alphatetris model type and return null feature metadata when appropriate
- ensure MLP-specific controls stay hidden for non-MLP types via reusable model-type predicates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc1d61e9f88322b6c840861420932f