### PR TITLE
Fix AlphaTetris planner column height initialization

### DIFF
--- a/web/js/training.js
+++ b/web/js/training.js
@@ -2797,6 +2797,12 @@ export function initTraining(game, renderer) {
         if(!model){
           return [];
         }
+
+        computeGridMetrics(grid);
+        for(let c = 0; c < WIDTH; c += 1){
+          baselineColumnMaskScratch[c] = columnMaskScratch[c] || 0;
+          baselineColumnHeightScratch[c] = columnHeightScratch[c] || 0;
+        }
         const alphaState = ensureAlphaState();
         const tf = (typeof window !== 'undefined' && window.tf) ? window.tf : null;
         if(!tf){


### PR DESCRIPTION
## Summary
- recompute board metrics before evaluating Alpha placements
- refresh cached column heights and masks so Alpha simulations see the current stack

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc5c05d87483229850d679fed597fb