### PR TITLE
Fix MCTS scoring to include immediate rewards

### DIFF
--- a/web/js/training.js
+++ b/web/js/training.js
@@ -3677,7 +3677,7 @@ export function initTraining(game, renderer) {
           const path = [{ node: root, reward: 0 }];
           let node = root;
           while(node.children && node.children.size > 0){
-            const [, child] = selectChild(node, cPuct);
+            const [, child] = selectChild(node, cPuct, discount);
             if(!child){
               break;
             }
@@ -3692,7 +3692,7 @@ export function initTraining(game, renderer) {
           backpropagate(path, leafValue, discount);
         }
 
-        const stats = visitStats(root);
+        const stats = visitStats(root, discount);
         const policyDistribution = computeVisitPolicy(stats, temperature);
         let chosen = null;
         if(temperature === 0){


### PR DESCRIPTION
## Summary
- include immediate rewards when computing child Q-values and the associated UCB selection logic so heuristics influence the search
- pass the search discount through MCTS selection and visit statistics to keep value reporting consistent

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ccd44a3d208322815f464eca737de7