### PR TITLE
Shorten training controls to prevent button wrapping

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -143,7 +143,7 @@
             title="Download current model weights"
             aria-label="Download current model weights"
           >
-            Save Weights
+            Save
           </button>
           <button
             id="upload-weights-button"
@@ -151,7 +151,7 @@
             title="Upload weights from a saved file"
             aria-label="Upload model weights"
           >
-            Load Weights
+            Load
           </button>
           <input id="upload-weights" type="file" accept=".txt,.json,text/plain" class="hidden" />
         </div>
@@ -181,7 +181,7 @@
             title="Start training"
             aria-label="Start training"
           >
-            Start Training
+            Start
           </button>
           <button
             id="reset-model"
@@ -189,7 +189,7 @@
             title="Reset model parameters"
             aria-label="Reset model parameters"
           >
-            Reset Model Parameters
+            Reset Model
           </button>
         </div>
         <div class="mt-10 flex w-full flex-col items-center gap-4">

--- a/web/js/training.js
+++ b/web/js/training.js
@@ -2892,7 +2892,7 @@ export function initTraining(game, renderer) {
       updateTrainStatus();
       const btn = document.getElementById('start-training');
       if(btn){
-        btn.textContent = 'Stop Training';
+        btn.textContent = 'Stop';
         btn.classList.remove('icon-btn--violet');
         btn.classList.add('icon-btn--emerald');
         btn.setAttribute('title', 'Stop training');
@@ -2922,7 +2922,7 @@ export function initTraining(game, renderer) {
       resetAiPlanState();
       const btn = document.getElementById('start-training');
       if(btn){
-        btn.textContent = 'Start Training';
+        btn.textContent = 'Start';
         btn.classList.remove('icon-btn--emerald');
         btn.classList.add('icon-btn--violet');
         btn.setAttribute('title', 'Start training');

--- a/web/styles.css
+++ b/web/styles.css
@@ -220,6 +220,7 @@ canvas {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   width: 62px;
   height: 62px;
   border-radius: 22px;
@@ -317,6 +318,7 @@ canvas {
   min-width: 150px;
   padding: 0 1.8rem;
   font-size: 18px;
+  white-space: nowrap;
 }
 .control-toggle {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- shorten the training and weight management button labels so they stay readable on narrow layouts
- prevent the wide control buttons from shrinking or wrapping their text when the layout scales

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd048abc9483229852ff37aa7fc5b4