### PR TITLE
Embed AlphaTetris metrics inline with selectable plots

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -16,8 +16,13 @@
       href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css"
+    />
     <link rel="stylesheet" href="./styles.css" />
     <script src="./tailwind-config.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js" defer></script>
     <script src="https://cdn.tailwindcss.com" defer></script>
 
   </head>
@@ -210,6 +215,38 @@
           aria-live="polite"
         ></div>
         <div id="network-viz" aria-label="Network weight visualization" class="glass-panel mx-auto h-[260px] w-full overflow-hidden p-6"></div>
+        <div
+          id="alpha-metrics-panel"
+          class="glass-panel mx-auto w-full max-w-5xl rounded-3xl px-6 py-6 text-left"
+        >
+          <div class="alpha-metrics-header">
+            <div class="alpha-metrics-heading">
+              <span class="alpha-metrics-heading__eyebrow">AlphaTetris</span>
+              <h3 class="alpha-metrics-heading__title">ConvNet Training Metrics</h3>
+              <p class="alpha-metrics-description">
+                Pin the latest loss curves directly on the page and toggle the traces you care about while the
+                ConvNet trains.
+              </p>
+            </div>
+            <div class="alpha-metrics-control">
+              <label for="alpha-metrics-select" class="alpha-metrics-control__label">Show metrics</label>
+              <select
+                id="alpha-metrics-select"
+                class="alpha-metrics-select"
+                multiple
+                aria-label="Select which ConvNet metrics to plot"
+              >
+                <option value="loss" selected>Total Loss</option>
+                <option value="policy_loss" selected>Policy Loss</option>
+                <option value="value_loss" selected>Value Loss</option>
+              </select>
+            </div>
+          </div>
+          <p id="alpha-metric-empty" class="alpha-metric-empty" aria-live="polite">
+            ConvNet losses will appear once AlphaTetris training runs.
+          </p>
+          <div id="alpha-metric-plots" class="alpha-metric-plots" aria-live="polite"></div>
+        </div>
         <div class="mx-auto mt-4 w-full max-w-5xl space-y-2">
           <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-plum/70">
             <span>Model history</span>

--- a/web/styles.css
+++ b/web/styles.css
@@ -147,6 +147,234 @@ canvas {
   fill: rgba(249, 245, 255, 0.82);
   pointer-events: none;
 }
+.alpha-metrics-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+.alpha-metrics-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 36rem;
+}
+.alpha-metrics-heading__eyebrow {
+  font-size: 0.7rem;
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  color: rgba(141, 225, 173, 0.78);
+}
+.alpha-metrics-heading__title {
+  margin: 0;
+  font-size: 1.8rem;
+  font-family: "Instrument Serif", serif;
+  color: #f9f5ff;
+  text-shadow: 0 12px 28px rgba(15, 15, 36, 0.4);
+}
+.alpha-metrics-description {
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.6;
+  color: rgba(249, 245, 255, 0.72);
+}
+.alpha-metrics-control {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.55rem;
+  width: 100%;
+  max-width: 20rem;
+}
+.alpha-metrics-control__label {
+  font-size: 0.7rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: rgba(249, 245, 255, 0.6);
+}
+.alpha-metrics-select {
+  width: 100%;
+  min-height: 48px;
+  border-radius: 999px;
+  border: 1px solid rgba(249, 245, 255, 0.18);
+  background: rgba(12, 59, 46, 0.24);
+  color: #f9f5ff;
+  padding: 0.5rem 0.9rem;
+}
+.alpha-metrics-select:focus {
+  border-color: rgba(244, 247, 121, 0.7);
+  box-shadow: 0 0 0 3px rgba(244, 247, 121, 0.25);
+}
+.alpha-metrics-control .choices {
+  width: 100%;
+}
+.alpha-metrics-control .choices__inner {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  border-radius: 999px;
+  border: 1px solid rgba(249, 245, 255, 0.18);
+  background: rgba(12, 59, 46, 0.24);
+  color: #f9f5ff;
+  padding: 0.45rem 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(249, 245, 255, 0.05);
+}
+.alpha-metrics-control .choices.is-focused .choices__inner,
+.alpha-metrics-control .choices.is-open .choices__inner {
+  border-color: rgba(244, 247, 121, 0.7);
+  box-shadow: 0 0 0 3px rgba(244, 247, 121, 0.25);
+}
+.alpha-metrics-control .choices__list--multiple .choices__item {
+  background: rgba(94, 74, 227, 0.32);
+  border: 1px solid rgba(192, 159, 228, 0.55);
+  border-radius: 999px;
+  color: #f9f5ff;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  box-shadow: 0 10px 18px rgba(10, 10, 26, 0.32);
+}
+.alpha-metrics-control .choices__list--multiple .choices__item .choices__button {
+  border-left: none;
+  border-radius: 999px;
+  background: rgba(10, 10, 26, 0.35);
+  color: rgba(249, 245, 255, 0.85);
+  margin-left: 0.35rem;
+}
+.alpha-metrics-control .choices__list--dropdown,
+.alpha-metrics-control .choices__list[aria-expanded] {
+  border: 1px solid rgba(249, 245, 255, 0.18);
+  background: rgba(14, 22, 41, 0.95);
+  box-shadow: 0 20px 40px rgba(10, 10, 26, 0.45);
+  color: rgba(249, 245, 255, 0.85);
+}
+.alpha-metrics-control .choices__list--dropdown .choices__item--selectable,
+.alpha-metrics-control .choices__list[aria-expanded] .choices__item--selectable {
+  color: rgba(249, 245, 255, 0.85);
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+.alpha-metrics-control .choices__list--dropdown .choices__item--selectable.is-highlighted,
+.alpha-metrics-control .choices__list[aria-expanded] .choices__item--selectable.is-highlighted {
+  background: rgba(94, 74, 227, 0.3);
+  color: #f9f5ff;
+}
+.alpha-metrics-control .choices__input {
+  background: transparent;
+  color: #f9f5ff;
+}
+.alpha-metrics-control .choices__placeholder {
+  opacity: 0.72;
+  color: rgba(249, 245, 255, 0.6);
+}
+.alpha-metric-empty {
+  margin-top: 1.5rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  text-align: center;
+  color: rgba(249, 245, 255, 0.55);
+}
+.alpha-metric-empty.is-hidden {
+  display: none;
+}
+.alpha-metric-plots {
+  margin-top: 1.75rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+.alpha-metric-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.05rem 1.15rem 1.25rem;
+  border-radius: 24px;
+  border: 1px solid rgba(249, 245, 255, 0.16);
+  background: linear-gradient(135deg, rgba(12, 59, 46, 0.32), rgba(94, 74, 227, 0.12));
+  box-shadow: 0 18px 40px rgba(10, 10, 26, 0.35);
+}
+.alpha-metric-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.alpha-metric-card__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+.alpha-metric-card__swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--alpha-metric-color, rgba(244, 247, 121, 0.85));
+  box-shadow: 0 0 12px rgba(244, 247, 121, 0.35);
+}
+.alpha-metric-card__name {
+  font-size: 0.78rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(249, 245, 255, 0.68);
+}
+.alpha-metric-card__stats {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.18rem;
+  text-align: right;
+}
+.alpha-metric-card__value {
+  font-family: "Instrument Serif", serif;
+  font-size: 1.32rem;
+  color: #f9f5ff;
+}
+.alpha-metric-card__delta {
+  font-size: 0.74rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(141, 225, 173, 0.8);
+}
+.alpha-metric-card__delta[data-trend='down'] {
+  color: rgba(249, 115, 22, 0.78);
+}
+.alpha-metric-card__delta[data-trend='flat'] {
+  color: rgba(249, 245, 255, 0.58);
+}
+.alpha-metric-card__meta {
+  font-size: 0.72rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(249, 245, 255, 0.45);
+}
+.alpha-metric-card .alpha-metric-chart {
+  width: 100%;
+  height: 180px;
+  border-radius: 18px;
+  border: 1px solid rgba(249, 245, 255, 0.14);
+  background: radial-gradient(circle at 0% 0%, rgba(94, 74, 227, 0.12), rgba(12, 59, 46, 0.42));
+  box-shadow: inset 0 1px 0 rgba(249, 245, 255, 0.08);
+}
+@media (min-width: 768px) {
+  .alpha-metrics-header {
+    flex-direction: row;
+    align-items: flex-end;
+  }
+  .alpha-metrics-control {
+    align-items: flex-end;
+  }
+}
+@media (max-width: 640px) {
+  .alpha-metrics-heading__title {
+    font-size: 1.5rem;
+  }
+  .alpha-metric-card .alpha-metric-chart {
+    height: 160px;
+  }
+}
 .alpha-conv-viz {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- embed the AlphaTetris metrics history directly in the training page with a multi-select dropdown
- theme the metrics selector and cards to match the neon glass UI and include Choices.js for better UX
- replace the TFVis popup with custom canvas rendering, inline summaries, and selection handling for convnet metrics

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd02bc768083229ff02c44ad51c682