### PR TITLE
Adjust select dropdown background for desktop

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -610,6 +610,18 @@ select:focus {
   border-color: rgba(244, 247, 121, 0.7);
   box-shadow: 0 0 0 3px rgba(244, 247, 121, 0.25);
 }
+@media (min-width: 768px) {
+  select option {
+    background-color: rgba(14, 22, 41, 0.92);
+    color: #f9f5ff;
+  }
+
+  select option:checked,
+  select option:hover {
+    background-color: rgba(94, 74, 227, 0.45);
+    color: #f9f5ff;
+  }
+}
 input[type='range'] {
   width: 240px;
   accent-color: #f4f779;


### PR DESCRIPTION
## Summary
- ensure desktop select drop-down menus use a dark background to keep white text legible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd11d18eec832288f46ad2f63ca178