### PR TITLE
Smooth block reward plot with moving averages

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -543,8 +543,8 @@ canvas {
 }
 .block-metrics-legend__item {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-start;
+  justify-content: flex-start;
   gap: 0.75rem;
   padding: 0.65rem 0.8rem;
   border-radius: 18px;
@@ -562,6 +562,14 @@ canvas {
   background: var(--block-metric-color, rgba(249, 245, 255, 0.82));
   box-shadow: 0 0 12px var(--block-metric-color, rgba(249, 245, 255, 0.42));
 }
+.block-metrics-legend__text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  flex: 1 1 auto;
+  min-width: 0;
+  gap: 0.2rem;
+}
 .block-metrics-legend__label {
   font-size: 0.74rem;
   letter-spacing: 0.28em;
@@ -572,7 +580,7 @@ canvas {
   font-size: 0.74rem;
   letter-spacing: 0.08em;
   color: rgba(249, 245, 255, 0.78);
-  text-align: right;
+  text-align: left;
 }
 @media (min-width: 768px) {
   .block-metrics-header {


### PR DESCRIPTION
## Summary
- recompute per-shape block metrics using the live history window and smooth the canvas plot with a floating average
- simplify the legend to show only the averaged reward and left-align the layout for readability

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd3537548c8322a568a5d126931f45