### PR TITLE
Optimize AlphaTetris input prep with reusable board metrics

### DIFF
--- a/web/js/models/__tests__/alphatetris.fastpath.test.mjs
+++ b/web/js/models/__tests__/alphatetris.fastpath.test.mjs
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  prepareAlphaInputs,
+  ALPHA_BOARD_WIDTH,
+  ALPHA_BOARD_HEIGHT,
+} from '../alphatetris.js';
+
+const ENGINEERED_FEATURE_LENGTH = 17;
+
+function createSampleGrid() {
+  const grid = Array.from({ length: ALPHA_BOARD_HEIGHT }, () => Array(ALPHA_BOARD_WIDTH).fill(0));
+  const bottom = ALPHA_BOARD_HEIGHT - 1;
+  grid[bottom][0] = 1;
+  grid[bottom - 1][0] = 1;
+  grid[bottom][1] = 1;
+  grid[bottom - 2][2] = 1;
+  grid[bottom - 3][2] = 1;
+  grid[bottom - 4][2] = 1;
+  grid[bottom][7] = 1;
+  grid[bottom - 1][7] = 1;
+  grid[bottom - 2][7] = 1;
+  grid[bottom - 3][7] = 1;
+  grid[bottom][9] = 1;
+  return grid;
+}
+
+function computeColumnMetrics(grid) {
+  const masks = typeof Uint32Array !== 'undefined'
+    ? new Uint32Array(ALPHA_BOARD_WIDTH)
+    : new Array(ALPHA_BOARD_WIDTH).fill(0);
+  const heights = new Array(ALPHA_BOARD_WIDTH).fill(0);
+  for (let row = 0; row < ALPHA_BOARD_HEIGHT; row += 1) {
+    const rowData = grid[row];
+    for (let col = 0; col < ALPHA_BOARD_WIDTH; col += 1) {
+      if (rowData[col]) {
+        masks[col] |= 1 << (ALPHA_BOARD_HEIGHT - 1 - row);
+      }
+    }
+  }
+  for (let col = 0; col < ALPHA_BOARD_WIDTH; col += 1) {
+    const mask = masks[col];
+    if (mask) {
+      heights[col] = (31 - Math.clz32(mask)) + 1;
+    }
+  }
+  return { masks, heights };
+}
+
+function engineeredFeatureVector() {
+  const feats = new Float32Array(ENGINEERED_FEATURE_LENGTH);
+  for (let i = 0; i < feats.length; i += 1) {
+    feats[i] = (i + 1) / (feats.length + 1);
+  }
+  return feats;
+}
+
+test('prepareAlphaInputs reuses provided column heights and masks', () => {
+  const grid = createSampleGrid();
+  const engineeredFeatures = engineeredFeatureVector();
+  const baseline = prepareAlphaInputs({ grid, engineeredFeatures });
+  const { masks, heights } = computeColumnMetrics(grid);
+  const heightTyped = typeof Uint8Array !== 'undefined' ? Uint8Array.from(heights) : heights.slice();
+  const maskTyped = typeof Uint32Array !== 'undefined' ? Uint32Array.from(masks) : masks.slice();
+  const fast = prepareAlphaInputs({ grid, engineeredFeatures }, {
+    columnHeights: heightTyped,
+    columnMasks: maskTyped,
+  });
+
+  assert.equal(fast.board.length, baseline.board.length);
+  for (let i = 0; i < fast.board.length; i += 1) {
+    assert.strictEqual(fast.board[i], baseline.board[i]);
+  }
+  assert.equal(fast.aux.length, baseline.aux.length);
+  for (let i = 0; i < fast.aux.length; i += 1) {
+    assert.strictEqual(fast.aux[i], baseline.aux[i]);
+  }
+});
+
+test('prepareAlphaInputs derives heights from provided column masks when needed', () => {
+  const grid = createSampleGrid();
+  const engineeredFeatures = engineeredFeatureVector();
+  const baseline = prepareAlphaInputs({ grid, engineeredFeatures });
+  const { masks } = computeColumnMetrics(grid);
+  const maskTyped = typeof Uint32Array !== 'undefined' ? Uint32Array.from(masks) : masks.slice();
+  const fast = prepareAlphaInputs({ grid, engineeredFeatures }, {
+    columnMasks: maskTyped,
+  });
+
+  assert.equal(fast.board.length, baseline.board.length);
+  for (let i = 0; i < fast.board.length; i += 1) {
+    assert.strictEqual(fast.board[i], baseline.board[i]);
+  }
+});

--- a/web/js/training.js
+++ b/web/js/training.js
@@ -5440,6 +5440,9 @@ export function initTraining(game, renderer) {
             lines: 0,
             newHoles: 0,
             engineeredFeatures: rootEngineeredFeatures,
+          }, {
+            columnHeights: baselineColumnHeightScratch,
+            columnMasks: baselineColumnMaskScratch,
           });
           rootMask = baseInputs.policyMask;
           if(alphaState){
@@ -5531,6 +5534,17 @@ export function initTraining(game, renderer) {
             topOut,
           });
 
+          const candidateColumnMasks = typeof Uint32Array !== 'undefined'
+            ? new Uint32Array(WIDTH)
+            : new Array(WIDTH).fill(0);
+          const candidateColumnHeights = typeof Uint8Array !== 'undefined'
+            ? new Uint8Array(WIDTH)
+            : new Array(WIDTH).fill(0);
+          for (let c = 0; c < WIDTH; c += 1) {
+            candidateColumnMasks[c] = columnMaskScratch[c] || 0;
+            candidateColumnHeights[c] = columnHeightScratch[c] || 0;
+          }
+
           const candidateState = {
             grid: sim.grid,
             active: activePieceForNext,
@@ -5542,6 +5556,8 @@ export function initTraining(game, renderer) {
             lines,
             newHoles: newHoleCount,
             engineeredFeatures,
+            columnMasks: candidateColumnMasks,
+            columnHeights: candidateColumnHeights,
           };
 
           candidateStates.push(candidateState);
@@ -5593,6 +5609,8 @@ export function initTraining(game, renderer) {
             boardOffset,
             auxBuffer: auxTensorData,
             auxOffset,
+            columnHeights: candidateStates[i].columnHeights,
+            columnMasks: candidateStates[i].columnMasks,
           });
         }
 


### PR DESCRIPTION
## Summary
- allow `prepareAlphaInputs`/`fillBoardTensor` to reuse provided column metrics or stats when preparing AlphaTetris tensors
- thread scratch column heights and masks through Alpha training evaluation so candidates reuse the precomputed data
- add node-based tests covering the fast path for precomputed column metrics

## Testing
- node --test --experimental-default-type=module web/js/models/__tests__/alphatetris.fastpath.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cd36f855e083228653f200e4ba9a6c