### PR TITLE
Integrate block rewards plot into training metrics panel

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -252,6 +252,7 @@
                   <option value="loss">Total Loss</option>
                   <option value="policy_loss">Policy Loss</option>
                   <option value="value_loss" selected>Value Loss</option>
+                  <option value="block_reward">Tetromino Objective Quality</option>
                 </select>
               </div>
             </div>
@@ -260,37 +261,6 @@
             ConvNet loss statistics will appear once AlphaTetris training runs.
           </p>
           <div id="alpha-metric-plots" class="alpha-metric-plots" aria-live="polite"></div>
-        </div>
-        <div
-          id="block-metrics-panel"
-          class="glass-panel mx-auto w-full max-w-5xl rounded-3xl px-6 py-6 text-left"
-        >
-          <div class="block-metrics-header">
-            <div class="block-metrics-heading">
-              <span class="block-metrics-heading__eyebrow">AlphaTetris</span>
-              <h3 class="block-metrics-heading__title">Tetromino Objective Quality</h3>
-              <p class="block-metrics-description">
-                Stream the planner's reward for every block placement and see which tetromino the
-                agent excels with.
-              </p>
-            </div>
-            <div id="block-metrics-favourite" class="block-metrics-favourite" aria-live="polite">
-              <span class="block-metrics-favourite__label">Favourite block</span>
-              <span class="block-metrics-favourite__value">—</span>
-            </div>
-          </div>
-          <p id="block-metrics-empty" class="block-metrics-empty" aria-live="polite">
-            Block reward statistics will appear once planning data is available.
-          </p>
-          <canvas
-            id="block-metrics-canvas"
-            width="520"
-            height="260"
-            class="block-metrics-canvas is-hidden"
-            role="img"
-            aria-label="Average reward per tetromino"
-          ></canvas>
-          <div id="block-metrics-legend" class="block-metrics-legend" aria-hidden="true"></div>
         </div>
         <div class="mx-auto mt-4 w-full max-w-5xl space-y-2">
           <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-plum/70">

--- a/web/styles.css
+++ b/web/styles.css
@@ -448,68 +448,6 @@ canvas {
     height: 160px;
   }
 }
-.block-metrics-header {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  align-items: flex-start;
-  justify-content: space-between;
-}
-.block-metrics-heading {
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
-  max-width: 36rem;
-}
-.block-metrics-heading__eyebrow {
-  font-size: 0.7rem;
-  letter-spacing: 0.42em;
-  text-transform: uppercase;
-  color: rgba(244, 247, 121, 0.78);
-}
-.block-metrics-heading__title {
-  margin: 0;
-  font-size: 1.8rem;
-  font-family: "Instrument Serif", serif;
-  color: #f9f5ff;
-  text-shadow: 0 12px 28px rgba(15, 15, 36, 0.4);
-}
-.block-metrics-description {
-  margin: 0;
-  font-size: 0.86rem;
-  line-height: 1.6;
-  color: rgba(249, 245, 255, 0.72);
-}
-.block-metrics-favourite {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.25rem;
-  padding: 0.75rem 1rem;
-  border-radius: 18px;
-  border: 1px solid rgba(249, 245, 255, 0.16);
-  background: linear-gradient(135deg, rgba(94, 74, 227, 0.16), rgba(12, 59, 46, 0.28));
-  box-shadow: 0 12px 24px rgba(10, 10, 26, 0.28);
-  min-width: 180px;
-}
-.block-metrics-favourite__label {
-  font-size: 0.62rem;
-  letter-spacing: 0.32em;
-  text-transform: uppercase;
-  color: rgba(249, 245, 255, 0.55);
-}
-.block-metrics-favourite__value {
-  font-size: 1.32rem;
-  font-family: "Instrument Serif", serif;
-  color: #f9f5ff;
-  text-shadow: 0 10px 22px rgba(15, 15, 36, 0.32);
-}
-.block-metrics-favourite__meta {
-  font-size: 0.7rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: rgba(141, 225, 173, 0.85);
-}
 .block-metrics-empty {
   margin-top: 1.5rem;
   font-size: 0.78rem;
@@ -581,15 +519,6 @@ canvas {
   letter-spacing: 0.08em;
   color: rgba(249, 245, 255, 0.78);
   text-align: left;
-}
-@media (min-width: 768px) {
-  .block-metrics-header {
-    flex-direction: row;
-    align-items: flex-end;
-  }
-  .block-metrics-favourite {
-    align-self: flex-start;
-  }
 }
 .alpha-conv-viz {
   display: flex;


### PR DESCRIPTION
## Summary
- expose the tetromino objective quality plot as a selectable alpha metric and remove the standalone panel
- update training metric rendering to draw the block reward card within the metrics list with a sorted legend and metadata
- drop the unused block metrics styling now that the favourite box is gone

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cd391c30208322a1365e1a553b5a69