### PR TITLE
Hide MCTS controls when model not AlphaTetris

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -111,7 +111,7 @@
             <span class="control-toggle__text">Show training (slow)</span>
           </label>
         </div>
-        <div class="controls flex flex-wrap items-center justify-center gap-4">
+        <div id="mcts-controls" class="controls hidden flex flex-wrap items-center justify-center gap-4">
           <label for="mcts-simulations" class="text-xs uppercase tracking-[0.35em] text-plum/70">Simulations</label>
           <input
             id="mcts-simulations"

--- a/web/js/training.js
+++ b/web/js/training.js
@@ -297,6 +297,7 @@ export function initTraining(game, renderer) {
   const mlpConfigEl = document.getElementById('mlp-config');
   const mlpHiddenCountSel = document.getElementById('mlp-hidden-count');
   const mlpLayerControlsEl = document.getElementById('mlp-layer-controls');
+  const mctsControlsEl = document.getElementById('mcts-controls');
   const mctsSimulationInput = document.getElementById('mcts-simulations');
   const mctsCpuctInput = document.getElementById('mcts-cpuct');
   const mctsTemperatureInput = document.getElementById('mcts-temperature');
@@ -1472,7 +1473,23 @@ export function initTraining(game, renderer) {
       }
     }
 
+    function syncMctsConfigVisibility(){
+      if(!mctsControlsEl){
+        return;
+      }
+      const trainState = (typeof window !== 'undefined' && window.__train) ? window.__train : null;
+      const activeModelType = (trainState && typeof trainState.modelType === 'string')
+        ? trainState.modelType
+        : currentModelType;
+      if(isAlphaModelType(activeModelType)){
+        mctsControlsEl.classList.remove('hidden');
+      } else {
+        mctsControlsEl.classList.add('hidden');
+      }
+    }
+
     function syncMctsControls(){
+      syncMctsConfigVisibility();
       if(!train || !train.ai || !train.ai.search){
         return;
       }
@@ -2017,6 +2034,7 @@ export function initTraining(game, renderer) {
       } else {
         mlpConfigEl.classList.add('hidden');
       }
+      syncMctsConfigVisibility();
     }
 
     function initMlpConfigUi(){


### PR DESCRIPTION
## Summary
- hide the Monte Carlo search parameter inputs by default in the training UI
- show the controls only when the AlphaTetris model is active by syncing visibility with the existing configuration helpers

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd44fa7a348322976c2dbe51252ce4