### PR TITLE
Fix training module syntax error that blocked UI controls

### DIFF
--- a/web/js/training.js
+++ b/web/js/training.js
@@ -7357,3 +7357,5 @@ export function initTraining(game, renderer, options = {}) {
   game.setGameOverHandler(onGameOver);
   return { train: window.__train, hooks };
 }
+
+}


### PR DESCRIPTION
## Summary
- add the missing closing brace to `initTraining` so the training module parses correctly
- unblock the main bootstrap so play/reset and other control buttons receive their event handlers again

## Testing
- Manual Playwright check to ensure the toggle button switches to the pause icon and no page errors occur

------
https://chatgpt.com/codex/tasks/task_e_68cd5a22c1748322abe1321f3103551a