### PR TITLE
Fix AlphaTetris weight export compression fallback

### DIFF
--- a/web/js/training.js
+++ b/web/js/training.js
@@ -1683,11 +1683,17 @@ export function initTraining(game, renderer, options = {}) {
             compression: null,
           };
           normalizedArtifacts = await normalizeAlphaModelArtifacts(sanitized);
-          if(decoded.compression){
-            normalizedArtifacts.originalCompression = decoded.compression;
+          const originalCompression = decoded.compression || decoded.originalCompression || null;
+          if(originalCompression){
+            normalizedArtifacts.originalCompression = originalCompression;
           }
-          if(typeof alpha.weightDataBase64 === 'string' && alpha.weightDataBase64){
-            normalizedArtifacts.encodedWeightDataBase64 = alpha.weightDataBase64;
+          const preferredBase64 = typeof alpha.compressedWeightDataBase64 === 'string' && alpha.compressedWeightDataBase64
+            ? alpha.compressedWeightDataBase64
+            : (typeof decoded.sourceBase64 === 'string' && decoded.sourceBase64
+              ? decoded.sourceBase64
+              : (typeof alpha.weightDataBase64 === 'string' && alpha.weightDataBase64 ? alpha.weightDataBase64 : null));
+          if(preferredBase64){
+            normalizedArtifacts.encodedWeightDataBase64 = preferredBase64;
           }
         } else {
           normalizedArtifacts = await normalizeAlphaModelArtifacts(alpha);


### PR DESCRIPTION
## Summary
- keep the AlphaTetris snapshot export JSON backwards compatible by storing a compressed copy alongside the original weight data
- harden weight decoding to fall back to the uncompressed payload when a browser cannot inflate gzip output and preserve compression metadata on import

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d1420a74288322ab116b9cab9d8d6c