### PR TITLE
Allow configuring training end level

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -107,6 +107,18 @@
             />
             <span class="control-toggle__text">Show training (slow)</span>
           </label>
+          <div class="flex items-center gap-2">
+            <label for="level-cap" class="text-xs uppercase tracking-[0.35em] text-plum/70">End Level</label>
+            <input
+              id="level-cap"
+              type="number"
+              min="1"
+              max="29"
+              step="1"
+              value="10"
+              class="w-20 bg-transparent text-base font-display text-left"
+            />
+          </div>
         </div>
         <div
           id="mcts-controls"


### PR DESCRIPTION
## Summary
- add an "End Level" numeric input to the training controls so the cap can be changed without reloading
- track the configurable level cap inside the training state with sanitisation and UI sync helpers
- enforce the user-selected cap during training runs while keeping the existing default of level 10

## Testing
- npm run build:tailwind

------
https://chatgpt.com/codex/tasks/task_e_68d1679acbc48322b9e61ea794b2ede7